### PR TITLE
Visibility on Insights

### DIFF
--- a/src/carbonarc/ontology.py
+++ b/src/carbonarc/ontology.py
@@ -174,8 +174,6 @@ class OntologyAPIClient(BaseAPIClient):
         for insight in response["items"]:
             if "sources" in insight:
                 insight.pop("sources")
-            if "blocked" in insight:
-                insight.pop("blocked")
 
         return response
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Exposes the `blocked` attribute in insights while continuing to omit `sources`.
> 
> - In `OntologyAPIClient.get_insights`, no longer `pop("blocked")` from each insight; only removes `sources` from response items.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b7316b3f462a97ab516b4b7034f9c2380b261b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->