### PR TITLE
Release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "carbonarc"
-version = "1.1.11"
+version = "1.1.12"
 description = "Carbon Arc - Python Package"
 authors = ["Carbon Arc <support@carbonarc.co>"]
 readme = "README.md"

--- a/src/carbonarc/ontology.py
+++ b/src/carbonarc/ontology.py
@@ -174,8 +174,6 @@ class OntologyAPIClient(BaseAPIClient):
         for insight in response["items"]:
             if "sources" in insight:
                 insight.pop("sources")
-            if "blocked" in insight:
-                insight.pop("blocked")
 
         return response
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Maintains `blocked` in insights payload while still stripping `sources`, and bumps package version.
> 
> - **API client:** `get_insights` now only removes `sources` from each item; `blocked` is preserved
> - **Release:** bump package version to `1.1.12`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4c5fd95445f534587369719f7af18c793a5d576. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->