### PR TITLE
Add search parameter to get_entities and get_insights methods in OntologyAPIClient

### DIFF
--- a/src/carbonarc/ontology.py
+++ b/src/carbonarc/ontology.py
@@ -41,6 +41,7 @@ class OntologyAPIClient(BaseAPIClient):
 
     def get_entities(
         self,
+        search: Optional[str] = None,
         representation: Optional[List[str]] = None,
         domain: Optional[Union[str, List[str]]] = None,
         entity: Optional[List[Literal["brand", "company", "people", "location"]]] = None,
@@ -58,6 +59,7 @@ class OntologyAPIClient(BaseAPIClient):
         Retrieve entities with filtering and pagination.
 
         Args:
+            search: Search query to filter entities by.
             entity_representation: List of entity representations to filter by.
             entity_domain: Entity domain(s) to filter by.
             entity: List of entity types to filter by.
@@ -79,6 +81,8 @@ class OntologyAPIClient(BaseAPIClient):
             "sort_by": sort_by,
             "order": order
         }
+        if search:
+            params["search"] = search
         if subject_ids:
             params["subject_ids"] = subject_ids
         if topic_ids:
@@ -115,6 +119,7 @@ class OntologyAPIClient(BaseAPIClient):
 
     def get_insights(
         self,
+        search: Optional[str] = None,
         subject_ids: Optional[List[int]] = None,
         topic_ids: Optional[List[int]] = None,
         insight_types: Optional[List[Literal["metric", "event", "kpi", "marketshare", "cohort"]]] = None,
@@ -131,6 +136,7 @@ class OntologyAPIClient(BaseAPIClient):
         Retrieve insights with filtering and pagination.
 
         Args:
+            search: Search query to filter insights by.
             subject_ids: List of subject IDs to filter by.
             topic_ids: List of topic IDs to filter by.
             insight_types: List of insight types to filter by.
@@ -152,7 +158,8 @@ class OntologyAPIClient(BaseAPIClient):
             "sort_by": sort_by,
             "order": order
         }
-        
+        if search:
+            params["search"] = search
         if subject_ids:
             params["subject_ids"] = subject_ids
         if topic_ids:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, additive client-side query parameter change that only affects request filtering when `search` is provided.
> 
> **Overview**
> Adds an optional `search` parameter to `OntologyAPIClient.get_entities` and `OntologyAPIClient.get_insights`, and forwards it as a `search` query param when set.
> 
> Updates the docstrings accordingly; existing behavior is unchanged when `search` is omitted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fad323235c64ffc6ec5f01451b95908386a39ef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->