### PR TITLE
Release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "carbonarc"
-version = "1.1.11"
+version = "1.1.12"
 description = "Carbon Arc - Python Package"
 authors = ["Carbon Arc <support@carbonarc.co>"]
 readme = "README.md"

--- a/src/carbonarc/ontology.py
+++ b/src/carbonarc/ontology.py
@@ -41,7 +41,6 @@ class OntologyAPIClient(BaseAPIClient):
 
     def get_entities(
         self,
-        search: Optional[str] = None,
         representation: Optional[List[str]] = None,
         domain: Optional[Union[str, List[str]]] = None,
         entity: Optional[List[Literal["brand", "company", "people", "location"]]] = None,
@@ -49,6 +48,7 @@ class OntologyAPIClient(BaseAPIClient):
         topic_ids: Optional[List[int]] = None,
         insight_types: Optional[List[Literal["metric", "event", "kpi", "marketshare", "cohort"]]] = None,
         insight_id: Optional[int] = None,
+        search: Optional[str] = None,
         version: Optional[str] = "latest",
         page: int = 1,
         size: int = 100,
@@ -59,14 +59,15 @@ class OntologyAPIClient(BaseAPIClient):
         Retrieve entities with filtering and pagination.
 
         Args:
-            search: Search query to filter entities by.
-            entity_representation: List of entity representations to filter by.
-            entity_domain: Entity domain(s) to filter by.
+            representation: List of entity representations to filter by.
+            domain: Entity domain(s) to filter by.
             entity: List of entity types to filter by.
             subject_ids: List of subject IDs to filter by.
             topic_ids: List of topic IDs to filter by.
             insight_types: List of insight types to filter by.
             insight_id: Insight ID to filter by.
+            search: Search query to filter entities by.
+            version: Ontology version to use for the query.
             page: Page number (default 1).
             size: Number of results per page (default 100).
             sort_by: Field to sort by.
@@ -119,7 +120,6 @@ class OntologyAPIClient(BaseAPIClient):
 
     def get_insights(
         self,
-        search: Optional[str] = None,
         subject_ids: Optional[List[int]] = None,
         topic_ids: Optional[List[int]] = None,
         insight_types: Optional[List[Literal["metric", "event", "kpi", "marketshare", "cohort"]]] = None,
@@ -127,6 +127,7 @@ class OntologyAPIClient(BaseAPIClient):
         entity_representation: Optional[str] = None,
         entity_domain: Optional[Union[str, List[str]]] = None,
         entity: Optional[Literal["brand", "company", "people", "location"]] = None,
+        search: Optional[str] = None,
         page: int = 1,
         size: int = 100,
         sort_by: str = "insight_label",
@@ -136,7 +137,6 @@ class OntologyAPIClient(BaseAPIClient):
         Retrieve insights with filtering and pagination.
 
         Args:
-            search: Search query to filter insights by.
             subject_ids: List of subject IDs to filter by.
             topic_ids: List of topic IDs to filter by.
             insight_types: List of insight types to filter by.
@@ -144,6 +144,7 @@ class OntologyAPIClient(BaseAPIClient):
             entity_representation: Entity representation to filter by.
             entity_domain: Entity domain(s) to filter by.
             entity: Entity type to filter by.
+            search: Search query to filter insights by.
             page: Page number (default 1).
             size: Number of results per page (default 100).
             sort_by: Field to sort by.

--- a/src/carbonarc/ontology.py
+++ b/src/carbonarc/ontology.py
@@ -41,6 +41,7 @@ class OntologyAPIClient(BaseAPIClient):
 
     def get_entities(
         self,
+        search: Optional[str] = None,
         representation: Optional[List[str]] = None,
         domain: Optional[Union[str, List[str]]] = None,
         entity: Optional[List[Literal["brand", "company", "people", "location"]]] = None,
@@ -58,6 +59,7 @@ class OntologyAPIClient(BaseAPIClient):
         Retrieve entities with filtering and pagination.
 
         Args:
+            search: Search query to filter entities by.
             entity_representation: List of entity representations to filter by.
             entity_domain: Entity domain(s) to filter by.
             entity: List of entity types to filter by.
@@ -79,6 +81,8 @@ class OntologyAPIClient(BaseAPIClient):
             "sort_by": sort_by,
             "order": order
         }
+        if search:
+            params["search"] = search
         if subject_ids:
             params["subject_ids"] = subject_ids
         if topic_ids:
@@ -115,6 +119,7 @@ class OntologyAPIClient(BaseAPIClient):
 
     def get_insights(
         self,
+        search: Optional[str] = None,
         subject_ids: Optional[List[int]] = None,
         topic_ids: Optional[List[int]] = None,
         insight_types: Optional[List[Literal["metric", "event", "kpi", "marketshare", "cohort"]]] = None,
@@ -131,6 +136,7 @@ class OntologyAPIClient(BaseAPIClient):
         Retrieve insights with filtering and pagination.
 
         Args:
+            search: Search query to filter insights by.
             subject_ids: List of subject IDs to filter by.
             topic_ids: List of topic IDs to filter by.
             insight_types: List of insight types to filter by.
@@ -152,7 +158,8 @@ class OntologyAPIClient(BaseAPIClient):
             "sort_by": sort_by,
             "order": order
         }
-        
+        if search:
+            params["search"] = search
         if subject_ids:
             params["subject_ids"] = subject_ids
         if topic_ids:

--- a/src/carbonarc/ontology.py
+++ b/src/carbonarc/ontology.py
@@ -174,8 +174,6 @@ class OntologyAPIClient(BaseAPIClient):
         for insight in response["items"]:
             if "sources" in insight:
                 insight.pop("sources")
-            if "blocked" in insight:
-                insight.pop("blocked")
 
         return response
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, backwards-compatible parameter additions to request query construction plus a minor response post-processing change.
> 
> **Overview**
> **Adds optional search filtering** to `OntologyAPIClient.get_entities` and `get_insights` via a new `search` argument that is forwarded as a query param, and updates the associated docstrings.
> 
> Also **bumps the package version** to `1.1.12` and stops stripping the `blocked` field from insight items (continues removing `sources`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca2ad222cc5ddd406682037b4aec9313ec118420. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->