### PR TITLE
Updated Docs and App Links in README with .ai suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ client = CarbonArcClient(token="<token>") # retrieve token from account
 ## Resources
 
 - [Tutorials](https://github.com/Carbon-Arc/carbonarc-tutorials)
-- [Docs](https://docs.carbonarc.co/)
+- [Docs](https://docs.carbonarc.ai/)
 - [App](https://app.carbonarc.co/)
 - [API](https://api.carbonarc.co/)

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ client = CarbonArcClient(token="<token>") # retrieve token from account
 
 - [Tutorials](https://github.com/Carbon-Arc/carbonarc-tutorials)
 - [Docs](https://docs.carbonarc.ai/)
-- [App](https://app.carbonarc.co/)
+- [App](https://app.carbonarc.ai/)
 - [API](https://api.carbonarc.co/)


### PR DESCRIPTION
## Summary
- Fixed the Docs link in the Resources section to use the `.ai` domain instead of `.co`, which no longer works
- Updated the App link in README.md to use the `.ai` domain for consistency

## Commits
- `b409165` — Fixed Docs Link in Resources to use .ai rather than .co that does not work anymore.
- `9a9697e` — Updated App Link in README.md as well for consistency

## Test plan
- [x] Verify all links in README.md resolve correctly with the `.ai` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates external links; no runtime behavior or API surface is affected.
> 
> **Overview**
> Updates the README Resources section to point **Docs** and **App** links at the `carbonarc.ai` domain (replacing the previous `.co` links).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fcf3e656e8edf30cb5c4851ff9bd5c1f146c0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->