### PR TITLE
Add get_dataset_schedule to SDK data.py

### DIFF
--- a/src/carbonarc/data.py
+++ b/src/carbonarc/data.py
@@ -93,6 +93,20 @@ class DataAPIClient(BaseAPIClient):
 
         return self._get(url, params=params)
 
+    def get_dataset_schedule(self, dataset_id: str) -> list:
+        """
+        Get the update schedule for a specific dataset from the Carbon Arc API.
+
+        Args:
+            dataset_id (str): The identifier of the dataset to retrieve the schedule for.
+
+        Returns:
+            list: A list of dictionaries containing schedule information for the specified dataset,
+                  including next_run_start, next_run_end, and last_update fields.
+        """
+        url = f"{self.base_data_url}/schedule/{dataset_id}"
+        return self._get(url)
+
     def get_graphs(
         self,
     ) -> dict:


### PR DESCRIPTION
## Summary
- Adds `get_dataset_schedule(dataset_id: str) -> list` method to `DataAPIClient` in `data.py`
- Surfaces the `GET /v2/library/schedule/{dataset_id}` endpoint, returning a list of schedule objects with `next_run_start`, `next_run_end`, and `last_update` fields
- Follows existing SDK patterns: URL constructed from `self.base_data_url`, docstring format, and `_get` helper
- No query parameters required; `dataset_id` is the only input

## Commits
`6c5a155` — Created a method for getting the Schedule for a specific dataset_id. This method surfaces the response from the library/schedule/{dataset_id} endpoint.

## Test plan
- [x] Install package in editable mode (`pip install -e .`) and instantiate `CarbonArcClient` with a valid token
- [x] Call `client.data.get_dataset_schedule("<dataset_id>")` with a known dataset ID
- [x] Confirm response is a list of dicts containing `next_run_start`, `next_run_end`, and `last_update` keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive SDK change that only introduces a new read-only API call and does not alter existing request/response handling.
> 
> **Overview**
> Adds `DataAPIClient.get_dataset_schedule(dataset_id)` to expose the dataset update schedule via `GET /v2/library/schedule/{dataset_id}`, returning the raw list payload from `_get` with no query params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c5a155785cba0388a6c81fe4850b906e2ac71ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->