### PR TITLE
PRO-1412: Add get_insights_by_dataset SDK method

### DIFF
--- a/src/carbonarc/data.py
+++ b/src/carbonarc/data.py
@@ -130,6 +130,19 @@ class DataAPIClient(BaseAPIClient):
 
         return self._get(url)
 
+    def get_insights_by_dataset(self, dataset_id: str) -> dict:
+        """
+        Retrieve all insights associated with a specific dataset.
+
+        Args:
+            dataset_id: The identifier of the dataset to retrieve insights for.
+
+        Returns:
+            Dictionary containing the insights for the specified dataset.
+        """
+        url = f"{self.base_data_url}/data/{dataset_id}/insights"
+        return self._get(url)
+
     def get_library_version_changes(
         self, 
         version: str = "latest",


### PR DESCRIPTION
This method will call the new API endpoint that was introduced in PRO-939. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single read-only SDK wrapper with no auth or data-write behavior; failure modes match other `_get` library calls.
> 
> **Overview**
> Adds **`get_insights_by_dataset(dataset_id)`** on `DataAPIClient`, exposing the library API’s dataset insights endpoint (`GET …/data/{dataset_id}/insights`) via the existing `_get` helper—same shape as other dataset-scoped read methods like `get_dataset_information`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b8725a4a14e153c799c5e706f2f952d30330ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->