### PR TITLE
Allow count_distinct aggregate in build_framework

### DIFF
--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -34,7 +34,7 @@ class ExplorerAPIClient(BaseAPIClient):
         entities: Union[List[Dict], Dict, str],
         insight: int,
         filters: Dict[str, Any],
-        aggregate: Optional[Literal["sum", "mean"]] = None
+        aggregate: Optional[Literal["sum", "mean", "count_distinct"]] = None
     ) -> dict:
         """
         Build a framework payload for the API.
@@ -43,7 +43,7 @@ class ExplorerAPIClient(BaseAPIClient):
             entities: List of entity dicts (with "carc_id" and "representation") or a representation string.
             insight: Insight ID.
             filters: Filters to apply.
-            aggregate: Aggregation method ("sum" or "mean").
+            aggregate: Aggregation method ("sum", "mean", or "count_distinct").
 
         Returns:
             Framework dictionary.


### PR DESCRIPTION
## What

Widen the `aggregate` parameter of `ExplorerAPIClient.build_framework` from `Literal["sum", "mean"]` to `Literal["sum", "mean", "count_distinct"]`, and update the docstring to match.

## Why

Found during the SDK ↔ docs parity check. The Carbon Arc framework API accepts `count_distinct` as an aggregation method alongside `sum` and `mean`, and the public documentation's Explorer API reference already lists `count_distinct` as a valid value. Only the SDK's type hint was lagging, so type-checkers and IDEs would incorrectly flag an otherwise-valid call.

This is a type-hint/docstring-only change; runtime behavior is unchanged (the value was already passed through to the API).

Part of the 2026-06-11 SDK ↔ docs parity sweep. See also the docs-side PR: Carbon-Arc/carbonarc-documentation#238.

🤖 Generated with Claude Code