### PR TITLE
PRO-968: Add events

### DIFF
--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -35,6 +35,7 @@ class ExplorerAPIClient(BaseAPIClient):
         insight: int,
         filters: Dict[str, Any],
         aggregate: Optional[Literal["sum", "mean"]] = None,
+        *,
         events: Optional[List[Dict]] = None,
     ) -> dict:
         """
@@ -61,6 +62,12 @@ class ExplorerAPIClient(BaseAPIClient):
                 f"insight must be an int, str, or dict (got {type(insight).__name__}). "
                 "build_framework(entities, insight, filters, aggregate=None, events=None) — "
                 "check your argument order."
+            )
+        if aggregate is not None and aggregate not in ("sum", "mean"):
+            raise InvalidConfigurationError(
+                f"aggregate must be 'sum', 'mean', or None (got {aggregate!r}). "
+                "events is a keyword-only argument — pass it as events=... rather "
+                "than positionally, e.g. build_framework(entities, insight, filters, events=my_events)."
             )
         framework: Dict[str, Any] = {
             "entities": self._clean_entities(entities),

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -104,10 +104,10 @@ class ExplorerAPIClient(BaseAPIClient):
             raise InvalidConfigurationError("Insight must have an 'insight_id' key.")
 
         if "events" in framework and framework["events"] is not None:
+            if not isinstance(framework["events"], list):
+                raise InvalidConfigurationError("Events must be a list of dicts.")
             framework["events"] = self._clean_events(framework["events"])
             events = framework["events"]
-            if not isinstance(events, list):
-                raise InvalidConfigurationError("Events must be a list of dicts.")
             for event in events:
                 if not isinstance(event, dict):
                     raise InvalidConfigurationError("Each event must be a dictionary.")

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -34,7 +34,8 @@ class ExplorerAPIClient(BaseAPIClient):
         entities: Union[List[Dict], Dict, str],
         insight: int,
         filters: Dict[str, Any],
-        aggregate: Optional[Literal["sum", "mean"]] = None
+        aggregate: Optional[Literal["sum", "mean"]] = None,
+        events: Optional[List[Dict]] = None,
     ) -> dict:
         """
         Build a framework payload for the API.
@@ -44,16 +45,24 @@ class ExplorerAPIClient(BaseAPIClient):
             insight: Insight ID.
             filters: Filters to apply.
             aggregate: Aggregation method ("sum" or "mean").
+            events: Optional list of event dicts, each with ``"event_id"`` (int)
+                and ``"representation"`` (str, e.g. ``"entityeventp"``).
+                Use ``client.ontology.get_event_types()`` to browse available
+                representations and ``client.ontology.get_events()`` to find
+                specific event IDs.
 
         Returns:
             Framework dictionary.
         """
-        return {
+        framework: Dict[str, Any] = {
             "entities": self._clean_entities(entities),
             "insight": self._clean_insight(insight),
             "filters": filters,
-            "aggregate": aggregate
+            "aggregate": aggregate,
         }
+        if events is not None:
+            framework["events"] = events
+        return framework
 
     def _validate_framework(self, framework: dict):
         """
@@ -88,7 +97,19 @@ class ExplorerAPIClient(BaseAPIClient):
             raise InvalidConfigurationError("Insight must be a dictionary.")
         if "insight_id" not in framework["insight"]:
             raise InvalidConfigurationError("Insight must have an 'insight_id' key.")
-        
+
+        if "events" in framework and framework["events"] is not None:
+            events = framework["events"]
+            if not isinstance(events, list):
+                raise InvalidConfigurationError("Events must be a list of dicts.")
+            for event in events:
+                if not isinstance(event, dict):
+                    raise InvalidConfigurationError("Each event must be a dictionary.")
+                if "event_id" not in event:
+                    raise InvalidConfigurationError("Each event must have an 'event_id' key.")
+                if "representation" not in event:
+                    raise InvalidConfigurationError("Each event must have a 'representation' key.")
+
         return framework
         
     @staticmethod

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -97,6 +97,7 @@ class ExplorerAPIClient(BaseAPIClient):
             raise InvalidConfigurationError("Insight must have an 'insight_id' key.")
 
         if "events" in framework and framework["events"] is not None:
+            framework["events"] = self._clean_events(framework["events"])
             events = framework["events"]
             if not isinstance(events, list):
                 raise InvalidConfigurationError("Events must be a list of dicts.")

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -76,13 +76,10 @@ class ExplorerAPIClient(BaseAPIClient):
             InvalidConfigurationError: If the framework is invalid.
         """
         
-        framework["entities"] = self._clean_entities(framework["entities"])
-        framework["insight"] = self._clean_insight(framework["insight"])
-        
         if not isinstance(framework, dict):
             raise InvalidConfigurationError("Framework must be a dictionary. Use build_framework().")
-        if "entities" not in framework:
-            raise InvalidConfigurationError("Framework must have an 'entities' key.")
+        framework["entities"] = self._clean_entities(framework.get("entities"))
+        framework["insight"] = self._clean_insight(framework["insight"])
         entities = framework["entities"]
         if isinstance(entities, list):
             if not all(isinstance(entity, dict) for entity in entities):

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -104,8 +104,8 @@ class ExplorerAPIClient(BaseAPIClient):
             for event in events:
                 if not isinstance(event, dict):
                     raise InvalidConfigurationError("Each event must be a dictionary.")
-                if "event_id" not in event:
-                    raise InvalidConfigurationError("Each event must have an 'event_id' key.")
+                if "event_id" not in event or event["event_id"] is None:
+                    raise InvalidConfigurationError("Each event must have a non-null 'event_id'.")
                 if "representation" not in event:
                     raise InvalidConfigurationError("Each event must have a 'representation' key.")
 
@@ -124,7 +124,7 @@ class ExplorerAPIClient(BaseAPIClient):
         if not events:
             return events
         return [
-            {**event, "event_id": str(event["event_id"])} if "event_id" in event else event
+            {**event, "event_id": str(event["event_id"])} if "event_id" in event and event["event_id"] is not None else event
             for event in events
         ]
 

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -62,7 +62,7 @@ class ExplorerAPIClient(BaseAPIClient):
             "aggregate": aggregate,
         }
         if events is not None:
-            framework["events"] = events
+            framework["events"] = self._clean_events(events)
         return framework
 
     def _validate_framework(self, framework: dict):
@@ -115,6 +115,18 @@ class ExplorerAPIClient(BaseAPIClient):
 
         return framework
         
+    @staticmethod
+    def _clean_events(events: Optional[List[Dict]]) -> Optional[List[Dict]]:
+        """
+        Clean the events list, coercing event_id to str as required by the API.
+        """
+        if not events:
+            return events
+        return [
+            {**event, "event_id": str(event["event_id"])} if "event_id" in event else event
+            for event in events
+        ]
+
     @staticmethod
     def _clean_entities(entities: Optional[Union[List[Dict], Dict, str]]) -> Union[List[Dict], Dict]:
         """

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -111,6 +111,11 @@ class ExplorerAPIClient(BaseAPIClient):
                 if "representation" not in event:
                     raise InvalidConfigurationError("Each event must have a 'representation' key.")
 
+        has_entities = bool(entities) if isinstance(entities, list) else entities is not None
+        has_events = bool(framework.get("events"))
+        if not has_entities and not has_events:
+            raise InvalidConfigurationError("Framework must have at least one entity or event.")
+
         return framework
         
     @staticmethod

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -31,9 +31,9 @@ class ExplorerAPIClient(BaseAPIClient):
 
     def build_framework(
         self,
-        entities: Union[List[Dict], Dict, str],
         insight: int,
         filters: Dict[str, Any],
+        entities: Optional[Union[List[Dict], Dict, str]] = None,
         aggregate: Optional[Literal["sum", "mean"]] = None,
         events: Optional[List[Dict]] = None,
     ) -> dict:

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -31,9 +31,9 @@ class ExplorerAPIClient(BaseAPIClient):
 
     def build_framework(
         self,
+        entities: Optional[Union[List[Dict], Dict, str]],
         insight: int,
         filters: Dict[str, Any],
-        entities: Optional[Union[List[Dict], Dict, str]] = None,
         aggregate: Optional[Literal["sum", "mean"]] = None,
         events: Optional[List[Dict]] = None,
     ) -> dict:
@@ -113,10 +113,13 @@ class ExplorerAPIClient(BaseAPIClient):
         return framework
         
     @staticmethod
-    def _clean_entities(entities: Union[List[Dict], Dict, str]) -> Union[List[Dict], Dict]:
+    def _clean_entities(entities: Optional[Union[List[Dict], Dict, str]]) -> Union[List[Dict], Dict]:
         """
         Clean the entities list.
         """
+        if entities is None:
+            return []
+
         if isinstance(entities, str):
             return {"carc_name": "*", "representation": entities}
         

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -31,9 +31,9 @@ class ExplorerAPIClient(BaseAPIClient):
 
     def build_framework(
         self,
+        entities: Optional[Union[List[Dict], Dict, str]],
         insight: int,
         filters: Dict[str, Any],
-        entities: Optional[Union[List[Dict], Dict, str]] = None,
         aggregate: Optional[Literal["sum", "mean"]] = None,
         events: Optional[List[Dict]] = None,
     ) -> dict:
@@ -41,10 +41,11 @@ class ExplorerAPIClient(BaseAPIClient):
         Build a framework payload for the API.
 
         Args:
+            entities: List of entity dicts (with "carc_id" and "representation") or a
+                representation string. Pass ``None`` for an event-only query (see
+                ``events``).
             insight: Insight ID.
             filters: Filters to apply.
-            entities: List of entity dicts (with "carc_id" and "representation") or a
-                representation string. Optional when ``events`` are provided (event-only query).
             aggregate: Aggregation method ("sum" or "mean").
             events: Optional list of event dicts, each with ``"event_id"`` (int)
                 and ``"representation"`` (str, e.g. ``"entityeventp"``).
@@ -55,6 +56,12 @@ class ExplorerAPIClient(BaseAPIClient):
         Returns:
             Framework dictionary.
         """
+        if not isinstance(insight, (int, str, dict)):
+            raise InvalidConfigurationError(
+                f"insight must be an int, str, or dict (got {type(insight).__name__}). "
+                "build_framework(entities, insight, filters, aggregate=None, events=None) — "
+                "check your argument order."
+            )
         framework: Dict[str, Any] = {
             "entities": self._clean_entities(entities),
             "insight": self._clean_insight(insight),

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -31,9 +31,9 @@ class ExplorerAPIClient(BaseAPIClient):
 
     def build_framework(
         self,
-        entities: Optional[Union[List[Dict], Dict, str]],
         insight: int,
         filters: Dict[str, Any],
+        entities: Optional[Union[List[Dict], Dict, str]] = None,
         aggregate: Optional[Literal["sum", "mean"]] = None,
         events: Optional[List[Dict]] = None,
     ) -> dict:
@@ -41,9 +41,10 @@ class ExplorerAPIClient(BaseAPIClient):
         Build a framework payload for the API.
 
         Args:
-            entities: List of entity dicts (with "carc_id" and "representation") or a representation string.
             insight: Insight ID.
             filters: Filters to apply.
+            entities: List of entity dicts (with "carc_id" and "representation") or a
+                representation string. Optional when ``events`` are provided (event-only query).
             aggregate: Aggregation method ("sum" or "mean").
             events: Optional list of event dicts, each with ``"event_id"`` (int)
                 and ``"representation"`` (str, e.g. ``"entityeventp"``).

--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -111,8 +111,12 @@ class ExplorerAPIClient(BaseAPIClient):
             for event in events:
                 if not isinstance(event, dict):
                     raise InvalidConfigurationError("Each event must be a dictionary.")
-                if "event_id" not in event or event["event_id"] is None:
-                    raise InvalidConfigurationError("Each event must have a non-null 'event_id'.")
+                has_event_id = event.get("event_id") is not None
+                has_event_category_id = event.get("event_category_id") is not None
+                if not has_event_id and not has_event_category_id:
+                    raise InvalidConfigurationError(
+                        "Each event must have a non-null 'event_id' or 'event_category_id'."
+                    )
                 if "representation" not in event:
                     raise InvalidConfigurationError("Each event must have a 'representation' key.")
 

--- a/src/carbonarc/ontology.py
+++ b/src/carbonarc/ontology.py
@@ -48,6 +48,8 @@ class OntologyAPIClient(BaseAPIClient):
         topic_ids: Optional[List[int]] = None,
         insight_types: Optional[List[Literal["metric", "event", "kpi", "marketshare", "cohort"]]] = None,
         insight_id: Optional[int] = None,
+        event_id: Optional[int] = None,
+        event_representation: Optional[str] = None,
         search: Optional[str] = None,
         version: Optional[str] = "latest",
         page: int = 1,
@@ -66,6 +68,9 @@ class OntologyAPIClient(BaseAPIClient):
             topic_ids: List of topic IDs to filter by.
             insight_types: List of insight types to filter by.
             insight_id: Insight ID to filter by.
+            event_id: Filter entities linked to this event ID.
+            event_representation: Event representation to use with ``event_id``
+                (e.g. ``"entityeventp"``).
             search: Search query to filter entities by.
             version: Ontology version to use for the query.
             page: Page number (default 1).
@@ -92,6 +97,10 @@ class OntologyAPIClient(BaseAPIClient):
             params["insight_types"] = insight_types
         if insight_id:
             params["insight_id"] = insight_id
+        if event_id:
+            params["event_id"] = event_id
+        if event_representation:
+            params["event_representation"] = event_representation
         if representation:
             params["entity_representation"] = representation
         if domain:
@@ -127,6 +136,8 @@ class OntologyAPIClient(BaseAPIClient):
         entity_representation: Optional[str] = None,
         entity_domain: Optional[Union[str, List[str]]] = None,
         entity: Optional[Literal["brand", "company", "people", "location"]] = None,
+        event_id: Optional[int] = None,
+        event_representation: Optional[str] = None,
         search: Optional[str] = None,
         page: int = 1,
         size: int = 100,
@@ -144,6 +155,9 @@ class OntologyAPIClient(BaseAPIClient):
             entity_representation: Entity representation to filter by.
             entity_domain: Entity domain(s) to filter by.
             entity: Entity type to filter by.
+            event_id: Filter insights linked to this event ID.
+            event_representation: Event representation to use with ``event_id``
+                (e.g. ``"entityeventp"``).
             search: Search query to filter insights by.
             page: Page number (default 1).
             size: Number of results per page (default 100).
@@ -175,6 +189,10 @@ class OntologyAPIClient(BaseAPIClient):
             params["entity_domain"] = entity_domain
         if entity:
             params["entity"] = entity
+        if event_id:
+            params["event_id"] = event_id
+        if event_representation:
+            params["event_representation"] = event_representation
 
         url = f"{self.base_ontology_url}/insights"
         response = self._get(url, params=params)
@@ -269,6 +287,59 @@ class OntologyAPIClient(BaseAPIClient):
         url = f"{self.base_ontology_url}/ontology-versions"
         return self._get(url)
     
+    def get_event_types(self) -> dict:
+        """
+        Retrieve available event types and their representations.
+
+        Returns:
+            Dictionary containing event types and their representation names.
+        """
+        url = f"{self.base_ontology_url}/event-types"
+        return self._get(url)
+
+    def get_events(
+        self,
+        insight_id: Optional[int] = None,
+        entity_id: Optional[int] = None,
+        entity_representation: Optional[str] = None,
+        search: Optional[str] = None,
+        min_score: Optional[float] = None,
+        page: int = 1,
+        size: int = 100,
+    ) -> dict:
+        """
+        Retrieve event entities, optionally filtered by insight, entity, or search query.
+
+        When ``search`` is provided the results are ranked by vector similarity
+        against the query; use ``min_score`` to control the relevance threshold.
+
+        Args:
+            insight_id: Filter events by insight ID.
+            entity_id: Filter events by entity ID.
+            entity_representation: Filter events by representation (e.g. ``"entityeventp"``).
+                Use :meth:`get_event_types` to see available representations.
+            search: Keyword query for vector-based event search.
+            min_score: Minimum similarity score when using ``search`` (0–1).
+            page: Page number (default 1).
+            size: Number of results per page (default 100).
+
+        Returns:
+            Dictionary containing paginated event entities.
+        """
+        params: Dict[str, Any] = {"page": page, "size": size}
+        if insight_id:
+            params["insight_id"] = insight_id
+        if entity_id:
+            params["entity_id"] = entity_id
+        if entity_representation:
+            params["entity_representation"] = entity_representation
+        if search:
+            params["search"] = search
+        if min_score is not None:
+            params["min_score"] = min_score
+        url = f"{self.base_ontology_url}/events"
+        return self._get(url, params=params)
+
     def get_ontology_version_changes_for_entities(
         self,
         version: str = "latest",

--- a/src/carbonarc/ontology.py
+++ b/src/carbonarc/ontology.py
@@ -297,6 +297,42 @@ class OntologyAPIClient(BaseAPIClient):
         url = f"{self.base_ontology_url}/event-types"
         return self._get(url)
 
+    def get_event_categories(
+        self,
+        event_type: Optional[str] = None,
+        insight_id: Optional[int] = None,
+        entity_id: Optional[int] = None,
+        entity_representation: Optional[str] = None,
+    ) -> dict:
+        """
+        Retrieve event categories grouped by event type.
+
+        When ``insight_id`` or ``entity_id`` + ``entity_representation`` are
+        provided, only categories present in that filtered context are returned.
+
+        Args:
+            event_type: Filter to a specific event type (e.g. ``"Corporate Events"``).
+            insight_id: Filter categories to those linked to this insight ID.
+            entity_id: Filter categories to those linked to this entity ID.
+            entity_representation: Required when ``entity_id`` is provided.
+
+        Returns:
+            Dictionary with an ``items`` list of category groups, each containing
+            ``event_type``, ``categories`` (list of ``{name, id}``), and
+            ``skip_parent_event`` (bool).
+        """
+        params: Dict[str, Any] = {}
+        if event_type:
+            params["event_type"] = event_type
+        if insight_id:
+            params["insight_id"] = insight_id
+        if entity_id:
+            params["entity_id"] = entity_id
+        if entity_representation:
+            params["entity_representation"] = entity_representation
+        url = f"{self.base_ontology_url}/event-categories"
+        return self._get(url, params=params)
+
     def get_events(
         self,
         insight_id: Optional[int] = None,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes framework validation and `build_framework` signatures, which can break misordered call sites; otherwise additive API surface on purchase/query paths.
> 
> **Overview**
> Adds **event-aware** querying across the Explorer framework builder and Ontology client.
> 
> **Explorer** — `build_framework` accepts an optional keyword-only `events` list and allows `entities=None` for event-only frameworks. Framework validation now normalizes and checks events (`event_id` or `event_category_id` plus `representation`), coerces `event_id` to strings for the API, and requires at least one entity or event. Extra guards catch swapped positional args (e.g. passing events where `aggregate` belongs).
> 
> **Ontology** — `get_entities` and `get_insights` gain `event_id` / `event_representation` query params. New helpers call `/event-types`, `/event-categories`, and `/events` (including vector search via `search` and `min_score`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b457ab46e0d726d76033768213acafc114d9e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->