### PR TITLE
fix: correct get_dataset_schedule return type to dict ({"schedules": [...]})

### DIFF
--- a/src/carbonarc/data.py
+++ b/src/carbonarc/data.py
@@ -93,7 +93,7 @@ class DataAPIClient(BaseAPIClient):
 
         return self._get(url, params=params)
 
-    def get_dataset_schedule(self, dataset_id: str) -> list:
+    def get_dataset_schedule(self, dataset_id: str) -> dict:
         """
         Get the update schedule for a specific dataset from the Carbon Arc API.
 
@@ -101,8 +101,9 @@ class DataAPIClient(BaseAPIClient):
             dataset_id (str): The identifier of the dataset to retrieve the schedule for.
 
         Returns:
-            list: A list of dictionaries containing schedule information for the specified dataset,
-                  including next_run_start, next_run_end, and last_update fields.
+            dict: A dictionary with a "schedules" key holding a list of schedule
+                  entries for the specified dataset. Each entry contains
+                  next_run_start, next_run_end, and last_update fields.
         """
         url = f"{self.base_data_url}/schedule/{dataset_id}"
         return self._get(url)


### PR DESCRIPTION
## What

`DataAPIClient.get_dataset_schedule()` was annotated `-> list` and its docstring claimed it returns "a list of dictionaries." It actually returns the endpoint payload unchanged, which is a **dict**: `{"schedules": [...]}`.

This corrects the return annotation to `dict` and rewrites the docstring to describe the real shape (a `schedules` key holding the entries, each with `next_run_start`, `next_run_end`, `last_update`).

## Why

The `/library/schedule/{dataset_id}` endpoint returns a `CakeTaskScheduleResponse` on the platform side:

```python
class CakeTaskScheduleItem(BaseModel):
    next_run_start: Optional[str] = None
    next_run_end: Optional[str] = None
    last_update: Optional[str] = None

class CakeTaskScheduleResponse(BaseModel):
    schedules: List[CakeTaskScheduleItem]
```

`get_dataset_schedule` does `return self._get(url)` with no reshaping, so callers get `{"schedules": [...]}`. The old annotation/docstring would lead callers to iterate the dict directly. The already-merged docs (`carbonarc-documentation` `library-api.md` "Get Dataset Schedule") correctly document the `{"schedules": [...]}` shape and `schedule_response.get('schedules', [])` — this change brings the SDK docstring into line with both the platform and the published docs.

> Note for reviewer: open docs PR Carbon-Arc/carbonarc-documentation#238 documents this method with a **bare-list** response shape, which contradicts the platform schema and the version already on `main`. It looks stale/superseded and is a candidate for closing.

## Verification
- Field names in the docstring match the platform `CakeTaskScheduleItem` schema exactly.
- `python3 -c "import ast; ast.parse(...)"` parses `data.py` cleanly.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and type-hint only; no logic or behavior changes.
> 
> **Overview**
> Updates **`DataAPIClient.get_dataset_schedule`** so its annotated return type and docstring match what the API actually returns: a **`dict`** with a **`schedules`** key (list of entries with `next_run_start`, `next_run_end`, `last_update`), not a bare list.
> 
> There is **no runtime change**—the method still returns `self._get(url)` unchanged. This only fixes misleading typing/docs that could cause callers to iterate the response as a list instead of using **`response["schedules"]`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b88f9bb80e93742159e30447e03817b72256270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->