### PR TITLE
feat: add client.block.rotate_polaris_credentials

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "carbonarc"
-version = "1.1.14"
+version = "1.1.15"
 description = "Carbon Arc - Python Package"
 authors = ["Carbon Arc <support@carbonarc.co>"]
 readme = "README.md"

--- a/src/carbonarc/block.py
+++ b/src/carbonarc/block.py
@@ -199,7 +199,7 @@ class BlockAPIClient(BaseAPIClient):
     """
     A client for Carbon Arc Block functionality:
     dataset discovery, trial-access request lifecycle, dataset pre-approvals,
-    and S3 ARN management.
+    S3 ARN management, and Polaris credential rotation.
     """
 
     def __init__(
@@ -644,3 +644,20 @@ class BlockAPIClient(BaseAPIClient):
     def deregister_arn(self, arn_id: str) -> dict:
         """Deregister a previously-registered ARN."""
         return self._delete(f"{self._v1_url}/arns/{arn_id}")
+
+    # ---- Polaris query-engine credentials -----------------------------------
+
+    def rotate_polaris_credentials(self) -> dict:
+        """Rotate the caller's Polaris (Iceberg REST Catalog) client
+        credentials.
+
+        Mints a fresh ``client_id`` / ``client_secret`` for the client's
+        existing Polaris principal and invalidates the previous pair
+        server-side. The returned secret is the only chance to capture it —
+        store it somewhere safe before discarding the response.
+
+        Returns:
+            Dict with ``principal_name``, ``client_id``, and
+            ``client_secret``.
+        """
+        return self._post(f"{self._v1_url}/polaris/rotate-credentials")


### PR DESCRIPTION
## What

Adds `BlockAPIClient.rotate_polaris_credentials()` to the Carbon Arc SDK, surfacing the user-facing CAMS endpoint:

```
POST /api/v1/block/polaris/rotate-credentials
```

It mints a fresh Polaris (Iceberg REST Catalog) `client_id` / `client_secret` for the caller's existing principal, invalidates the previous pair server-side, and returns `{principal_name, client_id, client_secret}`.

## Why (SDK ↔ platform drift)

Found by the scheduled SDK ↔ docs parity check. The endpoint already exists in the platform (`cake` → `app/cams/api/app/api/v1/routers/user_routers/block.py`), is gated on **Enterprise + any Block role** like the other `client.block.*` calls, and its handler docstring explicitly states:

> Exposed to the carbonarc SDK as `client.block.rotate_polaris_credentials`.

…but the SDK had no such method. The Block dev docs (`block-api.md` / `block-devs-overview.md`) already advertise **"Polaris credential rotation"** in the `client.block` namespace description, so the SDK was the side lagging behind the platform. This adds the missing method.

## Changes
- `src/carbonarc/block.py` — new `rotate_polaris_credentials()` method + class docstring updated.
- `pyproject.toml` — version bump `1.1.14` → `1.1.15` (drop if your release flow bumps separately).

## Docs
Matching documentation PR: https://github.com/Carbon-Arc/carbonarc-documentation/pull/252

## Notes / follow-up
- The sibling GET endpoint `/api/v1/block/credentials` (lazy-mints / returns current Polaris creds for the "Connect Your Query Engine" flow) is **not** surfaced here — only rotation was advertised in the docs and explicitly named for the SDK. Worth considering as a follow-up if a `get_polaris_credentials()` getter is desired.

🤖 Generated with Claude Code