### PR TITLE
Add block.rotate_polaris_credentials to BlockAPIClient

### DIFF
--- a/src/carbonarc/block.py
+++ b/src/carbonarc/block.py
@@ -644,3 +644,21 @@ class BlockAPIClient(BaseAPIClient):
     def deregister_arn(self, arn_id: str) -> dict:
         """Deregister a previously-registered ARN."""
         return self._delete(f"{self._v1_url}/arns/{arn_id}")
+
+    # ---- Phase 4b: Polaris credential rotation ------------------------------
+
+    def rotate_polaris_credentials(self) -> dict:
+        """Rotate the caller's Polaris (Iceberg REST Catalog) client
+        credentials.
+
+        Mints a fresh ``client_id`` / ``client_secret`` for the client's
+        existing Polaris principal and returns the new pair. The previous
+        credentials are invalidated server-side, so this response is the only
+        chance to capture the new secret. Requires an enterprise client whose
+        token carries a Block role — the same gating as the rest of the Block
+        surface.
+
+        Returns:
+            Dict with ``principal_name``, ``client_id``, and ``client_secret``.
+        """
+        return self._post(f"{self._v1_url}/polaris/rotate-credentials")


### PR DESCRIPTION
## Summary

Adds `client.block.rotate_polaris_credentials()` to `BlockAPIClient`, wrapping the customer-facing CAMS endpoint `POST /api/v1/block/polaris/rotate-credentials`. It mints a fresh Polaris `client_id` / `client_secret` for the caller's existing principal and returns the new pair (the old one is invalidated server-side).

## Why

The platform endpoint was added in cake `PRO-621` (#1681, 2026-06-18) and its docstring explicitly states:

> Exposed to the carbonarc SDK as `client.block.rotate_polaris_credentials`.

That endpoint landed **after** the SDK's Block feature-parity PR (#91, 2026-06-11) had already merged, so the SDK never gained the method — leaving the SDK lagging the platform. This closes the gap. The docs already advertise "Polaris credential rotation" in the Block API reference, but the body had no method to point at.

Detected by the automated SDK↔docs parity check.

## Notes

- No request body; the endpoint identifies the client from the auth token.
- Gating matches the rest of the Block surface (enterprise client + Block role), enforced server-side.

## Related

- Docs PR: https://github.com/Carbon-Arc/carbonarc-documentation/pull/256

🤖 Generated with Claude Code