### PR TITLE
PRO-1749: Add transcripts API client

### DIFF
--- a/src/carbonarc/base.py
+++ b/src/carbonarc/base.py
@@ -5,6 +5,7 @@ from carbonarc.explorer import ExplorerAPIClient
 from carbonarc.hub import HubAPIClient
 from carbonarc.client import PlatformAPIClient
 from carbonarc.ontology import OntologyAPIClient
+from carbonarc.transcripts import TranscriptAPIClient
 
 
 class CarbonArcClient:
@@ -44,3 +45,4 @@ class CarbonArcClient:
         self.hub = HubAPIClient(token=token, host=host, version=version)
         self.client = PlatformAPIClient(token=token, host=host, version=version)
         self.ontology = OntologyAPIClient(token=token, host=host, version=version)
+        self.transcripts = TranscriptAPIClient(token=token, host=host, version=version)

--- a/src/carbonarc/transcripts.py
+++ b/src/carbonarc/transcripts.py
@@ -1,0 +1,100 @@
+from typing import Optional
+
+from carbonarc.utils.client import BaseAPIClient
+
+
+class TranscriptAPIClient(BaseAPIClient):
+    """Client for the Carbon Arc Transcripts API.
+
+    Transcripts are expert interview recordings, delivered in three tiers:
+    raw, intelligence, and AI-RAG. Use this client to browse available
+    transcripts, purchase individual ones, and download the purchased files.
+
+    Access is gated by client entitlement — contact Carbon Arc to enable
+    Transcripts for your account.
+    """
+
+    def __init__(self, token: str, host: str, version: str):
+        super().__init__(token=token, host=host, version=version)
+        self._base_url = f"{host.rstrip('/')}/{version}/transcripts"
+
+    def list_transcripts(
+        self,
+        transcript_type: Optional[str] = None,
+        region: Optional[str] = None,
+        interview_date_from: Optional[str] = None,
+        interview_date_to: Optional[str] = None,
+    ) -> dict:
+        """List available transcripts for your account.
+
+        Returns transcripts your client is entitled to browse, ordered by
+        publish date descending. Each item includes an ``is_purchased`` flag
+        indicating whether the calling user has already purchased it.
+
+        Args:
+            transcript_type: Filter by transcript type (e.g. ``"expert_interview"``).
+            region: Filter by region (e.g. ``"North America"``).
+            interview_date_from: ISO date string lower bound, inclusive (e.g. ``"2024-01-01"``).
+            interview_date_to: ISO date string upper bound, inclusive (e.g. ``"2024-12-31"``).
+
+        Returns:
+            Dict with ``transcripts`` (list) and ``total`` (int).
+        """
+        params = {
+            k: v
+            for k, v in {
+                "transcript_type": transcript_type,
+                "region": region,
+                "interview_date_from": interview_date_from,
+                "interview_date_to": interview_date_to,
+            }.items()
+            if v is not None
+        }
+        return self._get(self._base_url, params=params)
+
+    def get_transcript(self, transcript_id: str) -> dict:
+        """Get metadata for a single transcript.
+
+        Returns full details including ontology entity tags and whether the
+        calling user has purchased this transcript.
+
+        Args:
+            transcript_id: UUID of the transcript.
+
+        Returns:
+            Dict with transcript metadata, ``has_pdf`` flag (whether a PDF
+            version is available), and ``is_purchased`` flag.
+        """
+        return self._get(f"{self._base_url}/{transcript_id}")
+
+    def purchase_transcript(self, transcript_id: str) -> dict:
+        """Purchase a transcript.
+
+        Deducts tokens from the calling user's balance. Returns the purchase
+        record including price and status. Raises a 402 if the balance is
+        insufficient and a 409 if already purchased.
+
+        Args:
+            transcript_id: UUID of the transcript to purchase.
+
+        Returns:
+            Dict with purchase details (``id``, ``transcript_id``, ``price``, ``status``, ``created_at``).
+        """
+        return self._post(f"{self._base_url}/{transcript_id}/purchase")
+
+    def download_transcript(self, transcript_id: str, fmt: str = "txt") -> dict:
+        """Get a presigned download URL for a purchased transcript.
+
+        The URL expires in 15 minutes. Also records the download for audit
+        purposes.
+
+        Args:
+            transcript_id: UUID of the purchased transcript.
+            fmt: File format — ``"txt"`` (default) or ``"pdf"``.
+
+        Returns:
+            Dict with ``url`` (presigned S3 URL), ``expires_in`` (seconds), and ``format``.
+        """
+        return self._get(
+            f"{self._base_url}/{transcript_id}/download", params={"fmt": fmt}
+        )

--- a/src/carbonarc/transcripts.py
+++ b/src/carbonarc/transcripts.py
@@ -6,9 +6,9 @@ from carbonarc.utils.client import BaseAPIClient
 class TranscriptAPIClient(BaseAPIClient):
     """Client for the Carbon Arc Transcripts API.
 
-    Transcripts are expert interview recordings, delivered in three tiers:
-    raw, intelligence, and AI-RAG. Use this client to browse available
-    transcripts, purchase individual ones, and download the purchased files.
+    Provides access to expert interview transcripts. Use this client to browse
+    available transcripts, purchase individual ones, and download the purchased
+    files.
 
     Access is gated by client entitlement — contact Carbon Arc to enable
     Transcripts for your account.
@@ -20,36 +20,52 @@ class TranscriptAPIClient(BaseAPIClient):
 
     def list_transcripts(
         self,
+        ticker: Optional[str] = None,
+        entity: Optional[str] = None,
         transcript_type: Optional[str] = None,
         region: Optional[str] = None,
+        search: Optional[str] = None,
         interview_date_from: Optional[str] = None,
         interview_date_to: Optional[str] = None,
+        sort_by: str = "published_at",
+        order: str = "desc",
+        page: int = 1,
+        size: int = 20,
     ) -> dict:
         """List available transcripts for your account.
 
-        Returns transcripts your client is entitled to browse, ordered by
-        publish date descending. Each item includes an ``is_purchased`` flag
-        indicating whether the calling user has already purchased it.
+        Returns transcripts your client is entitled to browse. Each item
+        includes an ``is_purchased`` flag indicating whether the calling user
+        has already purchased it.
 
         Args:
+            ticker: Filter by ticker symbol (entity label).
+            entity: Filter by any entity label.
             transcript_type: Filter by transcript type (e.g. ``"expert_interview"``).
             region: Filter by region (e.g. ``"North America"``).
+            search: Search in title and description.
             interview_date_from: ISO date string lower bound, inclusive (e.g. ``"2024-01-01"``).
             interview_date_to: ISO date string upper bound, inclusive (e.g. ``"2024-12-31"``).
+            sort_by: Sort field — ``"published_at"`` (default), ``"title"``, or ``"interview_date"``.
+            order: Sort direction — ``"desc"`` (default) or ``"asc"``.
+            page: Page number, 1-indexed (default ``1``).
+            size: Page size, 1–100 (default ``20``).
 
         Returns:
-            Dict with ``transcripts`` (list) and ``total`` (int).
+            Dict with ``transcripts`` (list), ``total`` (int), ``page`` (int), and ``size`` (int).
         """
-        params = {
-            k: v
-            for k, v in {
-                "transcript_type": transcript_type,
-                "region": region,
-                "interview_date_from": interview_date_from,
-                "interview_date_to": interview_date_to,
-            }.items()
-            if v is not None
-        }
+        params: dict = {"sort_by": sort_by, "order": order, "page": page, "size": size}
+        for key, val in {
+            "ticker": ticker,
+            "entity": entity,
+            "transcript_type": transcript_type,
+            "region": region,
+            "search": search,
+            "interview_date_from": interview_date_from,
+            "interview_date_to": interview_date_to,
+        }.items():
+            if val is not None:
+                params[key] = val
         return self._get(self._base_url, params=params)
 
     def get_transcript(self, transcript_id: str) -> dict:

--- a/src/carbonarc/transcripts.py
+++ b/src/carbonarc/transcripts.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from carbonarc.utils.client import BaseAPIClient
 
@@ -21,12 +21,13 @@ class TranscriptAPIClient(BaseAPIClient):
     def list_transcripts(
         self,
         ticker: Optional[str] = None,
-        entity: Optional[str] = None,
+        entity: Optional[List[str]] = None,
         transcript_type: Optional[str] = None,
         region: Optional[str] = None,
         search: Optional[str] = None,
         interview_date_from: Optional[str] = None,
         interview_date_to: Optional[str] = None,
+        is_purchased: Optional[bool] = None,
         sort_by: str = "published_at",
         order: str = "desc",
         page: int = 1,
@@ -40,12 +41,13 @@ class TranscriptAPIClient(BaseAPIClient):
 
         Args:
             ticker: Filter by ticker symbol (entity label).
-            entity: Filter by any entity label.
+            entity: Filter by one or more entity labels.
             transcript_type: Filter by transcript type (e.g. ``"expert_interview"``).
             region: Filter by region (e.g. ``"North America"``).
             search: Search in title and description.
             interview_date_from: ISO date string lower bound, inclusive (e.g. ``"2024-01-01"``).
             interview_date_to: ISO date string upper bound, inclusive (e.g. ``"2024-12-31"``).
+            is_purchased: If ``True``, return only purchased transcripts; if ``False``, only ones not yet purchased.
             sort_by: Sort field — ``"published_at"`` (default), ``"title"``, or ``"interview_date"``.
             order: Sort direction — ``"desc"`` (default) or ``"asc"``.
             page: Page number, 1-indexed (default ``1``).
@@ -57,7 +59,6 @@ class TranscriptAPIClient(BaseAPIClient):
         params: dict = {"sort_by": sort_by, "order": order, "page": page, "size": size}
         for key, val in {
             "ticker": ticker,
-            "entity": entity,
             "transcript_type": transcript_type,
             "region": region,
             "search": search,
@@ -66,6 +67,10 @@ class TranscriptAPIClient(BaseAPIClient):
         }.items():
             if val is not None:
                 params[key] = val
+        if entity is not None:
+            params["entity"] = entity
+        if is_purchased is not None:
+            params["is_purchased"] = is_purchased
         return self._get(self._base_url, params=params)
 
     def get_transcript(self, transcript_id: str) -> dict:


### PR DESCRIPTION
## Summary

- Adds `TranscriptAPIClient` (`src/carbonarc/transcripts.py`) with four methods: `list_transcripts`, `get_transcript`, `purchase_transcript`, `download_transcript`
- Wires `client.transcripts` into `CarbonArcClient` alongside existing sub-clients
- Targets the new public transcript endpoints on Power API (`/v2/transcripts/*`)

## Usage

```python
client = CarbonArcClient(token="...")

# Browse the catalog
transcripts = client.transcripts.list_transcripts(region="North America")

# Inspect a transcript
detail = client.transcripts.get_transcript("some-uuid")

# Purchase and download
client.transcripts.purchase_transcript("some-uuid")
download = client.transcripts.download_transcript("some-uuid", fmt="pdf")
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK client only; purchase behavior is delegated to existing API semantics with no changes to shared auth or HTTP infrastructure in this PR.
> 
> **Overview**
> Adds SDK support for the Power API **transcripts** surface so callers can use `client.transcripts` like the other sub-clients.
> 
> New **`TranscriptAPIClient`** (`transcripts.py`) targets `{host}/{version}/transcripts` and exposes **list** (filters, pagination, sort), **get** metadata, **purchase** (POST, token balance), and **download** (presigned URL for `txt`/`pdf`). **`CarbonArcClient`** is extended with `self.transcripts` using the same `token` / `host` / `version` wiring as catalog, data, ontology, etc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 202e22afdf3b56ffa20f7d8806ef1c21c092aca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->