### PR TITLE
feat: add block.rotate_polaris_credentials (SDK was lagging the platform)

### DIFF
--- a/src/carbonarc/block.py
+++ b/src/carbonarc/block.py
@@ -644,3 +644,24 @@ class BlockAPIClient(BaseAPIClient):
     def deregister_arn(self, arn_id: str) -> dict:
         """Deregister a previously-registered ARN."""
         return self._delete(f"{self._v1_url}/arns/{arn_id}")
+
+    # ---- Polaris credential rotation ----------------------------------------
+
+    def rotate_polaris_credentials(self) -> dict:
+        """Rotate the caller's Polaris (Iceberg REST Catalog) client
+        credentials.
+
+        Mints a fresh ``client_id`` / ``client_secret`` for the client's
+        existing Polaris principal and invalidates the previous pair
+        server-side. The returned ``client_secret`` is the only chance to
+        capture the new value — update any query engine connected via Polaris
+        (Snowflake, ClickHouse, …) with the new pair, or it will lose access.
+
+        Gated like the rest of the Block surface: an enterprise client whose
+        token carries a Block role.
+
+        Returns:
+            Dict with ``principal_name`` (may be ``None``), ``client_id``, and
+            ``client_secret``.
+        """
+        return self._post(f"{self._v1_url}/polaris/rotate-credentials")


### PR DESCRIPTION
## What

Adds `client.block.rotate_polaris_credentials()` to the SDK.

## Why — the SDK was lagging the platform

The CAMS platform already ships the endpoint this method calls:

- `POST /api/v1/block/polaris/rotate-credentials` → `rotate_block_polaris_credentials` (`app/cams/api/app/api/v1/routers/user_routers/block.py`)
- Returns `BlockRotatedCredentials` = `{ principal_name: str | None, client_id: str, client_secret: str }` (`app/cams/api/app/schemas/block.py`)

Both the endpoint docstring and the `BlockRotatedCredentials` schema docstring **name the SDK method by hand** — "Exposed to the carbonarc SDK as `client.block.rotate_polaris_credentials`" — but the published SDK never added it. Meanwhile the docs and the `CarbonArcClient` docstring already describe Polaris credential rotation as part of the `client.block` surface. So this is a clear "SDK lagging the platform" gap, not a docs over-claim.

## Change

A single bodyless `POST` to the existing endpoint, mirroring the other `client.block` methods:

```python
def rotate_polaris_credentials(self) -> dict:
    return self._post(f"{self._v1_url}/polaris/rotate-credentials")
```

No version bump included — this repo bumps `pyproject.toml` in dedicated release commits; bump before the next publish.

## Related documentation PRs (carbonarc-documentation)

This resolves a contradictory pile-up of docs-parity PRs that prior automated runs opened because the SDK method was missing:

- **Become correct once this ships** (they document the method): Carbon-Arc/carbonarc-documentation#256, Carbon-Arc/carbonarc-documentation#252
- **Become obsolete** (they delete the Polaris-rotation wording to match the lagging SDK): Carbon-Arc/carbonarc-documentation#250, Carbon-Arc/carbonarc-documentation#248, Carbon-Arc/carbonarc-documentation#244

Recommendation: merge this SDK PR together with docs #256 (or #252), then close the "drop the claim" docs PRs (#250/#248/#244) as obsolete.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single thin API wrapper with no auth or request-shape changes beyond calling an already-shipped platform route.
> 
> **Overview**
> Adds **`client.block.rotate_polaris_credentials()`** so the published SDK matches the CAMS Block API and existing platform/docs references.
> 
> The method issues a bodyless **`POST`** to **`/api/v1/block/polaris/rotate-credentials`** (same pattern as other Block helpers) and returns **`principal_name`**, **`client_id`**, and **`client_secret`**. Docstrings note that the new secret is shown once and that engines using Polaris must be updated after rotation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f19fe9f6f45553f2abafb8b96cea79e2847775f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->