### PR TITLE
PLA-4006: Add tearsheet PDF download to data client

### DIFF
--- a/src/carbonarc/data.py
+++ b/src/carbonarc/data.py
@@ -55,7 +55,60 @@ class DataAPIClient(BaseAPIClient):
         url = f"{self.base_data_url}/{endpoint}"
 
         return self._get(url)
-    
+
+    def get_tearsheet_pdf(self, dataset_id: str) -> bytes:
+        """
+        Retrieve the tearsheet PDF for a specific dataset as raw bytes.
+
+        Args:
+            dataset_id (str): The identifier of the dataset to retrieve the tearsheet PDF for.
+
+        Returns:
+            bytes: The raw PDF content of the dataset's tearsheet.
+
+        Raises:
+            requests.exceptions.HTTPError: If the API request fails, e.g. a 404
+                when the dataset id does not exist or a 401 when the
+                authentication token is missing or invalid.
+        """
+        endpoint = f"data/{dataset_id}/tearsheet-pdf"
+        url = f"{self.base_data_url}/{endpoint}"
+
+        return self._stream(url).content
+
+    def download_tearsheet_pdf(self, dataset_id: str, directory: Optional[str] = None) -> str:
+        """
+        Download the tearsheet PDF for a specific dataset to a local file.
+
+        The file is written as ``tearsheet_{dataset_id}.pdf`` in the target
+        directory, which is created if it does not already exist. An existing
+        file at the same path is overwritten.
+
+        Args:
+            dataset_id (str): The identifier of the dataset to download the tearsheet PDF for.
+            directory (Optional[str]): The directory where the file should be saved.
+                Defaults to the current directory when not provided. The directory
+                will be created if it doesn't exist.
+
+        Returns:
+            str: The absolute path to the written PDF file.
+
+        Raises:
+            requests.exceptions.HTTPError: If the API request fails, e.g. a 404
+                when the dataset id does not exist or a 401 when the
+                authentication token is missing or invalid.
+            OSError: If there are file system errors (permissions, disk space, etc.).
+        """
+        pdf_bytes = self.get_tearsheet_pdf(dataset_id)
+        file_name = f"tearsheet_{dataset_id}.pdf"
+        output_dir = os.path.abspath(directory if directory is not None else ".")
+        os.makedirs(output_dir, exist_ok=True)
+        file_path = os.path.join(output_dir, file_name)
+        with open(file_path, "wb") as f:
+            f.write(pdf_bytes)
+
+        return file_path
+
     def get_data_dictionary(self, 
                             dataset_id: str,
                             entity_topic_id: Optional[int] = None) -> dict:


### PR DESCRIPTION
## Summary

- Adds `get_tearsheet_pdf(dataset_id) -> bytes` to `DataAPIClient` (`client.data`), targeting `GET /library/data/{dataset_id}/tearsheet-pdf` and returning the raw PDF bytes.
- Adds `download_tearsheet_pdf(dataset_id, directory=None) -> str`, which writes the bytes to `tearsheet_{dataset_id}.pdf` (created dir, binary write, overwrite) and returns the absolute file path.
- Mirrors the request/auth wiring of the existing `get_dataset_information` metadata method and the directory handling of `download_webcontent_file`.

This is the SDK half of PLA-4006; the Power API half is already merged.

## Usage

```python
client = CarbonArcClient(token="...")

pdf_bytes = client.data.get_tearsheet_pdf("CA0030")
path = client.data.download_tearsheet_pdf("CA0030", directory="downloads")
```

## Notes

- Scoped to the two new methods only; no changes to the shared HTTP/error layer. Failed requests surface as `requests.exceptions.HTTPError` (404 = unknown dataset id, 401 = bad/missing token), documented in the `Raises:` docstrings.
- No backend contract changes.

## Test plan

- [ ] `client.data.download_tearsheet_pdf("CA0030")` writes a valid PDF (bytes start with `%PDF`) against a dev token
- [ ] Unknown dataset id raises `requests.exceptions.HTTPError` (404)

Made with [Cursor](https://cursor.com)