### PR TITLE
Version Bump: Release-2026-07-02

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "carbonarc"
-version = "1.1.14"
+version = "1.1.15"
 description = "Carbon Arc - Python Package"
 authors = ["Carbon Arc <support@carbonarc.co>"]
 readme = "README.md"

--- a/src/carbonarc/base.py
+++ b/src/carbonarc/base.py
@@ -5,6 +5,7 @@ from carbonarc.explorer import ExplorerAPIClient
 from carbonarc.hub import HubAPIClient
 from carbonarc.client import PlatformAPIClient
 from carbonarc.ontology import OntologyAPIClient
+from carbonarc.transcripts import TranscriptAPIClient
 
 
 class CarbonArcClient:
@@ -44,3 +45,4 @@ class CarbonArcClient:
         self.hub = HubAPIClient(token=token, host=host, version=version)
         self.client = PlatformAPIClient(token=token, host=host, version=version)
         self.ontology = OntologyAPIClient(token=token, host=host, version=version)
+        self.transcripts = TranscriptAPIClient(token=token, host=host, version=version)

--- a/src/carbonarc/data.py
+++ b/src/carbonarc/data.py
@@ -55,7 +55,60 @@ class DataAPIClient(BaseAPIClient):
         url = f"{self.base_data_url}/{endpoint}"
 
         return self._get(url)
-    
+
+    def get_tearsheet_pdf(self, dataset_id: str) -> bytes:
+        """
+        Retrieve the tearsheet PDF for a specific dataset as raw bytes.
+
+        Args:
+            dataset_id (str): The identifier of the dataset to retrieve the tearsheet PDF for.
+
+        Returns:
+            bytes: The raw PDF content of the dataset's tearsheet.
+
+        Raises:
+            requests.exceptions.HTTPError: If the API request fails, e.g. a 404
+                when the dataset id does not exist or a 401 when the
+                authentication token is missing or invalid.
+        """
+        endpoint = f"data/{dataset_id}/tearsheet-pdf"
+        url = f"{self.base_data_url}/{endpoint}"
+
+        return self._stream(url).content
+
+    def download_tearsheet_pdf(self, dataset_id: str, directory: Optional[str] = None) -> str:
+        """
+        Download the tearsheet PDF for a specific dataset to a local file.
+
+        The file is written as ``tearsheet_{dataset_id}.pdf`` in the target
+        directory, which is created if it does not already exist. An existing
+        file at the same path is overwritten.
+
+        Args:
+            dataset_id (str): The identifier of the dataset to download the tearsheet PDF for.
+            directory (Optional[str]): The directory where the file should be saved.
+                Defaults to the current directory when not provided. The directory
+                will be created if it doesn't exist.
+
+        Returns:
+            str: The absolute path to the written PDF file.
+
+        Raises:
+            requests.exceptions.HTTPError: If the API request fails, e.g. a 404
+                when the dataset id does not exist or a 401 when the
+                authentication token is missing or invalid.
+            OSError: If there are file system errors (permissions, disk space, etc.).
+        """
+        pdf_bytes = self.get_tearsheet_pdf(dataset_id)
+        file_name = f"tearsheet_{dataset_id}.pdf"
+        output_dir = os.path.abspath(directory if directory is not None else ".")
+        os.makedirs(output_dir, exist_ok=True)
+        file_path = os.path.join(output_dir, file_name)
+        with open(file_path, "wb") as f:
+            f.write(pdf_bytes)
+
+        return file_path
+
     def get_data_dictionary(self, 
                             dataset_id: str,
                             entity_topic_id: Optional[int] = None) -> dict:

--- a/src/carbonarc/transcripts.py
+++ b/src/carbonarc/transcripts.py
@@ -1,0 +1,121 @@
+from typing import List, Optional
+
+from carbonarc.utils.client import BaseAPIClient
+
+
+class TranscriptAPIClient(BaseAPIClient):
+    """Client for the Carbon Arc Transcripts API.
+
+    Provides access to expert interview transcripts. Use this client to browse
+    available transcripts, purchase individual ones, and download the purchased
+    files.
+
+    Access is gated by client entitlement — contact Carbon Arc to enable
+    Transcripts for your account.
+    """
+
+    def __init__(self, token: str, host: str, version: str):
+        super().__init__(token=token, host=host, version=version)
+        self._base_url = f"{host.rstrip('/')}/{version}/transcripts"
+
+    def list_transcripts(
+        self,
+        ticker: Optional[str] = None,
+        entity: Optional[List[str]] = None,
+        transcript_type: Optional[str] = None,
+        region: Optional[str] = None,
+        search: Optional[str] = None,
+        interview_date_from: Optional[str] = None,
+        interview_date_to: Optional[str] = None,
+        is_purchased: Optional[bool] = None,
+        sort_by: str = "published_at",
+        order: str = "desc",
+        page: int = 1,
+        size: int = 20,
+    ) -> dict:
+        """List available transcripts for your account.
+
+        Returns transcripts your client is entitled to browse. Each item
+        includes an ``is_purchased`` flag indicating whether the calling user
+        has already purchased it.
+
+        Args:
+            ticker: Filter by ticker symbol (entity label).
+            entity: Filter by one or more entity labels.
+            transcript_type: Filter by transcript type (e.g. ``"expert_interview"``).
+            region: Filter by region (e.g. ``"North America"``).
+            search: Search in title and description.
+            interview_date_from: ISO date string lower bound, inclusive (e.g. ``"2024-01-01"``).
+            interview_date_to: ISO date string upper bound, inclusive (e.g. ``"2024-12-31"``).
+            is_purchased: If ``True``, return only purchased transcripts; if ``False``, only ones not yet purchased.
+            sort_by: Sort field — ``"published_at"`` (default), ``"title"``, or ``"interview_date"``.
+            order: Sort direction — ``"desc"`` (default) or ``"asc"``.
+            page: Page number, 1-indexed (default ``1``).
+            size: Page size, 1–100 (default ``20``).
+
+        Returns:
+            Dict with ``transcripts`` (list), ``total`` (int), ``page`` (int), and ``size`` (int).
+        """
+        params: dict = {"sort_by": sort_by, "order": order, "page": page, "size": size}
+        for key, val in {
+            "ticker": ticker,
+            "transcript_type": transcript_type,
+            "region": region,
+            "search": search,
+            "interview_date_from": interview_date_from,
+            "interview_date_to": interview_date_to,
+        }.items():
+            if val is not None:
+                params[key] = val
+        if entity is not None:
+            params["entity"] = entity
+        if is_purchased is not None:
+            params["is_purchased"] = is_purchased
+        return self._get(self._base_url, params=params)
+
+    def get_transcript(self, transcript_id: str) -> dict:
+        """Get metadata for a single transcript.
+
+        Returns full details including ontology entity tags and whether the
+        calling user has purchased this transcript.
+
+        Args:
+            transcript_id: UUID of the transcript.
+
+        Returns:
+            Dict with transcript metadata, ``has_pdf`` flag (whether a PDF
+            version is available), and ``is_purchased`` flag.
+        """
+        return self._get(f"{self._base_url}/{transcript_id}")
+
+    def purchase_transcript(self, transcript_id: str) -> dict:
+        """Purchase a transcript.
+
+        Deducts tokens from the calling user's balance. Returns the purchase
+        record including price and status. Raises a 402 if the balance is
+        insufficient and a 409 if already purchased.
+
+        Args:
+            transcript_id: UUID of the transcript to purchase.
+
+        Returns:
+            Dict with purchase details (``id``, ``transcript_id``, ``price``, ``status``, ``created_at``).
+        """
+        return self._post(f"{self._base_url}/{transcript_id}/purchase")
+
+    def download_transcript(self, transcript_id: str, fmt: str = "txt") -> dict:
+        """Get a presigned download URL for a purchased transcript.
+
+        The URL expires in 15 minutes. Also records the download for audit
+        purposes.
+
+        Args:
+            transcript_id: UUID of the purchased transcript.
+            fmt: File format — ``"txt"`` (default) or ``"pdf"``.
+
+        Returns:
+            Dict with ``url`` (presigned S3 URL), ``expires_in`` (seconds), and ``format``.
+        """
+        return self._get(
+            f"{self._base_url}/{transcript_id}/download", params={"fmt": fmt}
+        )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New purchase/download flows touch billing and presigned URLs; tearsheet download writes local files and overwrites existing paths, but changes are additive client wrappers with no auth redesign.
> 
> **Overview**
> Bumps the package to **1.1.15** and extends the Python SDK with two API surfaces.
> 
> **Transcripts:** `CarbonArcClient` now exposes `client.transcripts` via a new `TranscriptAPIClient` for listing/filtering expert interview transcripts, fetching metadata, purchasing (token balance), and obtaining presigned download URLs for txt/pdf.
> 
> **Data library:** `DataAPIClient` adds `get_tearsheet_pdf` (raw bytes via streaming) and `download_tearsheet_pdf` (writes `tearsheet_{dataset_id}.pdf` locally, creating the target directory if needed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38a50cb1ea3124a3e1d31c319613a5127e2cf2bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->