### PR TITLE
fix: allow count_distinct aggregate in build_framework

### DIFF
--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -34,7 +34,7 @@ class ExplorerAPIClient(BaseAPIClient):
         entities: Optional[Union[List[Dict], Dict, str]],
         insight: int,
         filters: Dict[str, Any],
-        aggregate: Optional[Literal["sum", "mean"]] = None,
+        aggregate: Optional[Literal["sum", "mean", "count_distinct"]] = None,
         *,
         events: Optional[List[Dict]] = None,
     ) -> dict:
@@ -47,7 +47,7 @@ class ExplorerAPIClient(BaseAPIClient):
                 ``events``).
             insight: Insight ID.
             filters: Filters to apply.
-            aggregate: Aggregation method ("sum" or "mean").
+            aggregate: Aggregation method ("sum", "mean", or "count_distinct").
             events: Optional list of event dicts, each with ``"event_id"`` (int)
                 and ``"representation"`` (str, e.g. ``"entityeventp"``).
                 Use ``client.ontology.get_event_types()`` to browse available
@@ -63,9 +63,9 @@ class ExplorerAPIClient(BaseAPIClient):
                 "build_framework(entities, insight, filters, aggregate=None, events=None) — "
                 "check your argument order."
             )
-        if aggregate is not None and aggregate not in ("sum", "mean"):
+        if aggregate is not None and aggregate not in ("sum", "mean", "count_distinct"):
             raise InvalidConfigurationError(
-                f"aggregate must be 'sum', 'mean', or None (got {aggregate!r}). "
+                f"aggregate must be 'sum', 'mean', 'count_distinct', or None (got {aggregate!r}). "
                 "events is a keyword-only argument — pass it as events=... rather "
                 "than positionally, e.g. build_framework(entities, insight, filters, events=my_events)."
             )


### PR DESCRIPTION
## What drifted

`build_framework(aggregate=...)` rejects `count_distinct`, a value the platform supports.

The source of truth is gateau:

```python
# packages/gateau/src/gateau/framework/constants.py
AGGREGATE_TYPES = Literal["sum", "mean", "count_distinct"]
```

power-api types the request field with it directly, so `count_distinct` is valid for `POST /v2/framework/*`:

```python
# app/power-api/app/api/v2/schemas/framework.py
aggregate: Optional[AGGREGATE_TYPES] = None
```

The SDK's type hint only ever listed `"sum"` and `"mean"`. That was a cosmetic mismatch until the argument-order guards landed on 2026-07-21 (`9a4fc18..52b457a`), which added:

```python
if aggregate is not None and aggregate not in ("sum", "mean"):
    raise InvalidConfigurationError(...)
```

That turned the stale hint into a hard failure. `count_distinct` now raises before the request is built, so a supported platform aggregate is unreachable from the SDK.

## Verified

Against this branch:

```
OK  aggregate='sum' -> 'sum'
OK  aggregate='mean' -> 'mean'
OK  aggregate='count_distinct' -> 'count_distinct'
OK  aggregate=None -> None
OK  rejected 'median'
OK  rejected 'count'
OK  rejected 'average'
```

`median` and `count` stay rejected on purpose — they are not in `AGGREGATE_TYPES` and the API 422s on them. Some docs pages still list them; that is fixed on the docs side (see below).

## Supersedes #88

#88 makes the same fix but only to the type hint. It predates the runtime guard, so merging it alone would leave `count_distinct` still raising. This PR covers the hint, the docstring, and the guard. #88 can be closed.

## Related

Docs-side counterpart: Carbon-Arc/carbonarc-documentation#288 — drops the nonexistent `median`/`count` aggregates from the reference tables and fixes the Events examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow SDK validation fix with no auth or data-path changes; only expands an allowed enum value to match the API.
> 
> **Overview**
> **`build_framework`** now treats **`count_distinct`** as a valid **`aggregate`**, matching the platform API instead of only **`sum`** and **`mean`**.
> 
> The change updates the **`Literal`** type hint, docstring, and the runtime check that raises **`InvalidConfigurationError`**—so **`aggregate='count_distinct'`** can be passed through to framework requests again instead of failing client-side.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddf7118e1a84bca9b4335ca9d70b7f4bca217bd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->