### PR TITLE
fix: drop query params the platform no longer accepts (+ dead graph-data route)

### DIFF
--- a/src/carbonarc/catalog.py
+++ b/src/carbonarc/catalog.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal, Optional
 
 from carbonarc.utils.client import BaseAPIClient
 
@@ -19,10 +19,9 @@ class CatalogAPIClient(BaseAPIClient):
 
     def list_assets(
         self,
-        tier: Optional[Union[int, list]] = None,
+        tier: Optional[int] = None,
         provider_id: Optional[str] = None,
         category: Optional[str] = None,
-        visibility: Optional[str] = None,
         search: Optional[str] = None,
         data_type: Optional[str] = None,
         geography: Optional[str] = None,
@@ -36,7 +35,6 @@ class CatalogAPIClient(BaseAPIClient):
             tier: Filter by asset tier (1, 2, or 3).
             provider_id: Filter by provider UUID.
             category: Filter by data category.
-            visibility: Filter by visibility ('public', 'gated', 'locked').
             search: Case-insensitive title search.
             data_type: Filter by data type.
             geography: Filter by geography (exact match within array field).
@@ -50,7 +48,6 @@ class CatalogAPIClient(BaseAPIClient):
             "tier": tier,
             "provider_id": provider_id,
             "category": category,
-            "visibility": visibility,
             "search": search,
             "data_type": data_type,
             "geography": geography,
@@ -103,7 +100,8 @@ class CatalogAPIClient(BaseAPIClient):
     ) -> dict:
         """
         Submit an access request for a gated or locked asset.
-        Only valid for non-public assets. Raises 409 if an active request already exists.
+        Only valid for non-public assets. Repeat submissions for the same asset
+        are allowed — each one is logged as a new request.
 
         Args:
             asset_id: UUID of the asset to request access to.

--- a/src/carbonarc/data.py
+++ b/src/carbonarc/data.py
@@ -184,18 +184,9 @@ class DataAPIClient(BaseAPIClient):
     
     def get_graph_data(self, graph_id: str, download_type: Literal["csv", "json", "graphml"] = "csv") -> dict:
         """
-        Get the information for a specific dataset from the Carbon Arc API.
-        
-        Args:
-            data_identifier (str): The identifier of the data to retrieve information for.
-            
-        Returns:
-            dict: A dictionary containing the information for the specified dataset.
+        Download the files for a graph identifier.
         """
-        endpoint = f"graph/{graph_id}/data"
-        url = f"{self.base_data_url}/{endpoint}?download_type={download_type}"
-
-        return self._get(url)
+        raise NotImplementedError("get_graph_data() has been deprecated and is not available in the API. Please use get_graph_information() for graph metadata.")
 
     def get_insights_by_dataset(self, dataset_id: str) -> dict:
         """

--- a/src/carbonarc/ontology.py
+++ b/src/carbonarc/ontology.py
@@ -44,9 +44,6 @@ class OntologyAPIClient(BaseAPIClient):
         representation: Optional[List[str]] = None,
         domain: Optional[Union[str, List[str]]] = None,
         entity: Optional[List[Literal["brand", "company", "people", "location"]]] = None,
-        subject_ids: Optional[List[int]] = None,
-        topic_ids: Optional[List[int]] = None,
-        insight_types: Optional[List[Literal["metric", "event", "kpi", "marketshare", "cohort"]]] = None,
         insight_id: Optional[int] = None,
         event_id: Optional[int] = None,
         event_representation: Optional[str] = None,
@@ -64,9 +61,6 @@ class OntologyAPIClient(BaseAPIClient):
             representation: List of entity representations to filter by.
             domain: Entity domain(s) to filter by.
             entity: List of entity types to filter by.
-            subject_ids: List of subject IDs to filter by.
-            topic_ids: List of topic IDs to filter by.
-            insight_types: List of insight types to filter by.
             insight_id: Insight ID to filter by.
             event_id: Filter entities linked to this event ID.
             event_representation: Event representation to use with ``event_id``
@@ -89,12 +83,6 @@ class OntologyAPIClient(BaseAPIClient):
         }
         if search:
             params["search"] = search
-        if subject_ids:
-            params["subject_ids"] = subject_ids
-        if topic_ids:
-            params["topic_ids"] = topic_ids
-        if insight_types:
-            params["insight_types"] = insight_types
         if insight_id:
             params["insight_id"] = insight_id
         if event_id:


### PR DESCRIPTION
## What drifted

Four places where the SDK's public surface promises something the platform no longer does. Each was verified against `origin/main` of `Carbon-Arc/cake`.

### 1. `catalog.list_assets(visibility=...)` — silently ignored

`visibility` was removed from `GET /v2/catalog/assets` in **PRO-867** (`Carbon-Arc/cake` #927, 2026-05-11), which collapsed `is_early_access` / `is_premium` into one gating model. The SDK still accepts it and puts it on the query string, documented as `Filter by visibility ('public', 'gated', 'locked')`.

FastAPI ignores unknown query params, so `list_assets(visibility="public")` returns **200 with every asset the caller can see** — a wrong answer, not an error.

### 2. `catalog.list_assets(tier=[1, 2])` — only one tier is honored

The param is annotated `Optional[Union[int, list]]`, but the route declares `tier: Optional[int] = Query(None, ge=1, le=3)`. A list serializes to `?tier=1&tier=2`, and Starlette's `QueryParams.get()` returns the **last** value, so only `tier=2` is applied. Narrowed to `Optional[int]` to match.

### 3. `catalog.request_access()` — docstring documents a 409 that cannot happen

The docstring says `Raises 409 if an active request already exists`. The route deliberately does the opposite — `app/api/v2/services/catalog.py` carries the comment *"Intentionally no duplicate guard: users may submit again (e.g. follow-up or forgot)"*, and there is no 409 anywhere in the catalog service or route.

### 4. `ontology.get_entities(subject_ids=, topic_ids=, insight_types=)` — silently ignored

Removed from `GET /v2/ontology/entities` in `Carbon-Arc/cake` commit `589b0737fb8` (2025-12-05). Same failure mode as `visibility`: unfiltered results, no error. All three are still valid on `get_insights()` and are untouched there.

### 5. `data.get_graph_data()` — 404 since 2025-10-22

`GET /v2/library/graph/{graph_id}/data` is **commented out** on the platform (`app/power-api/app/api/v2/routes/datalibrary.py`, above the surviving `/graph/{graph_id}` route), disabled in commit `2f125e46d82` with the note `## TODO -- This has no buy option and should be relooked at`. Every call has 404'd for nine months.

Made it raise `NotImplementedError` with a pointer to `get_graph_information()`, following the existing `PlatformAPIClient.get_usage()` precedent in this repo rather than deleting the method — a caller upgrading gets a readable message instead of a `TypeError` or a 404 body.

## Reviewer call needed: this removes public params

Dropping `visibility`, `subject_ids`, `topic_ids` and `insight_types` turns a silent wrong answer into a `TypeError: unexpected keyword argument`. That is the point — the current behavior hands back unfiltered data that looks filtered — but it **is** a breaking signature change. If you would rather accept-and-warn for a release first, say so and I will swap it.

I did **not** bump the version; choosing minor-vs-patch for a surface removal is your call.

## Also noticed, not fixed here

- `GET /v2/catalog/assets` gained a `liked_only` filter the SDK does not expose.
- `ontology.get_ontology_version()` and `get_ontology_versions()` both call `/ontology-versions`, so they return the same payload despite the singular/plural naming.

## Companion docs PR

The same three phantom `get_entities` filters are documented in the docs repo: Carbon-Arc/carbonarc-documentation#299

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public method signatures (TypeError for removed kwargs) and behavior change for `get_graph_data()` callers; fixes incorrect silent filtering but requires coordinated SDK upgrades.
> 
> **Overview**
> Aligns the Python SDK with **platform behavior** so callers no longer get silently wrong results from ignored query params or dead routes.
> 
> **Catalog:** Drops `visibility` from `list_assets` (no longer accepted by the API). Narrows `tier` to `Optional[int]` so list values are not misleadingly supported. Updates `request_access` docs to reflect that repeat requests are allowed instead of a 409 on duplicates.
> 
> **Ontology:** Removes `subject_ids`, `topic_ids`, and `insight_types` from `get_entities` (removed from the entities endpoint; still available on `get_insights`).
> 
> **Data:** `get_graph_data()` now raises **`NotImplementedError`** with guidance to use `get_graph_information()`, since the graph data download route is gone.
> 
> Removing these kwargs is a **breaking signature change** for code that still passes them; the tradeoff is explicit failure instead of unfiltered data that looks filtered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ca0d51096990241f92ca726e68b397a810be554. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->