### PR TITLE
fix: check_framework_price return type + get_events docstring (verified against power-api)

### DIFF
--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -213,7 +213,7 @@ class ExplorerAPIClient(BaseAPIClient):
         url = f"{self.base_framework_url}/filters"
         return self._post(url, json={"framework": framework})
     
-    def check_framework_price(self, framework: dict) -> dict:
+    def check_framework_price(self, framework: dict) -> Optional[float]:
         """
         Check the price of a framework.
 
@@ -221,7 +221,8 @@ class ExplorerAPIClient(BaseAPIClient):
             framework: Framework dictionary.
 
         Returns:
-            Dictionary of available filters.
+            The quoted price in tokens, or None when the platform returns no
+            price for the framework.
         """
         framework = self._validate_framework(framework)
         url = f"{self.base_framework_url}/order"

--- a/src/carbonarc/ontology.py
+++ b/src/carbonarc/ontology.py
@@ -346,21 +346,30 @@ class OntologyAPIClient(BaseAPIClient):
         """
         Retrieve event entities, optionally filtered by insight, entity, or search query.
 
-        When ``search`` is provided the results are ranked by vector similarity
-        against the query; use ``min_score`` to control the relevance threshold.
+        When ``search`` is provided the results are ranked by relevance against
+        the query; use ``min_score`` to control the relevance threshold. On the
+        search path ``entity_id``/``entity_representation`` are only applied
+        when ``insight_id`` is also given, and the reported ``total`` reflects
+        the capped batch the search returns.
 
         Args:
             insight_id: Filter events by insight ID.
-            entity_id: Filter events by entity ID.
-            entity_representation: Filter events by representation (e.g. ``"entityeventp"``).
-                Use :meth:`get_event_types` to see available representations.
-            search: Keyword query for vector-based event search.
-            min_score: Minimum similarity score when using ``search`` (0–1).
+            entity_id: carc_id of a non-event entity to filter events by.
+            entity_representation: Representation of the entity given in
+                ``entity_id`` (e.g. ``"artist"``, ``"ticker"``). Required
+                whenever ``entity_id`` is provided; supplying only one of the
+                pair raises a validation error.
+            search: Keyword query for event search.
+            min_score: Minimum relevance score when using ``search`` (0–1).
             page: Page number (default 1).
             size: Number of results per page (default 100).
 
         Returns:
-            Dictionary containing paginated event entities.
+            Dictionary with ``total``, ``page``, ``size``, ``pages`` and an
+            ``entities`` list. Each entry carries ``carc_id``, ``carc_name``,
+            ``entity_representation_name``, ``event_type``,
+            ``event_category``/``event_category_id`` and, for search results,
+            ``relevance_score``.
         """
         params: Dict[str, Any] = {"page": page, "size": size}
         if insight_id:


### PR DESCRIPTION
Two public-surface docstring/annotation errors found by the daily SDK↔docs parity check, both verified against the live platform routes in the `cake` monorepo.

## 1. `check_framework_price` claims to return a dict

```python
price = self._post(url, json={"framework": framework}).get("price", None)
return price
```

It returns the unwrapped `price` value, but the annotation says `-> dict` and the `Returns:` line reads "Dictionary of available filters" — copy-pasted from `collect_framework_filters`.

`POST /v2/framework/order` responds with `FrameworkQuoteResponse`, whose `price` is `Optional[float]`, so the correct annotation is `Optional[float]`.

This is user-visible: [`docs/platform/consumption-pricing/framework-pricing.md`](https://github.com/Carbon-Arc/carbonarc-documentation/blob/main/docs/platform/consumption-pricing/framework-pricing.md) followed the docstring and wrote `price.get('price')`, which raises `AttributeError` on a float. Fixed on the docs side in Carbon-Arc/carbonarc-documentation#304.

## 2. `get_events` mislabels `entity_representation`

The docstring described it as the *event's* representation (`"entityeventp"`) and pointed at `get_event_types`. On `GET /v2/ontology/events` it is the representation of the **non-event** entity named by `entity_id` (e.g. `"artist"`, `"ticker"`), and the route raises a validation error if only one of the pair is supplied.

Also documented, from the same route and `OntologyEventService`:

- the response envelope is `{total, page, size, pages, entities}` — `entities`, not `items`
- on the search path, `entity_id`/`entity_representation` are only applied when `insight_id` is also given (`_search_events` forwards them as `related_entity_*` only in that case)
- search `total` reflects the capped fetch batch, so it can understate broad queries

No behavior change — annotation and docstrings only.

---

### Also found, not fixed here

The platform has had a **customer-facing** `POST /api/v1/block/polaris/rotate-credentials` route in CAMS since `97142f164ff` (2026-06-18, PRO-621), and its own docstring says it is "Exposed to the carbonarc SDK as `client.block.rotate_polaris_credentials`". `BlockAPIClient` still has no such method.

**#97 already implements this correctly** (right URL, right response keys, `principal_name` documented as nullable, MERGEABLE) — it should be merged rather than reimplemented, and #94 (CONFLICTING, carries an unrelated version bump) / #95 can be closed in its favour. I deliberately did not open a fourth duplicate.

A previous run of this check concluded the opposite — that the method was a phantom — because it only compared the SDK against the docs and never checked CAMS. That conclusion is wrong, and the corresponding hunks in Carbon-Arc/carbonarc-documentation#287 (which *remove* "Polaris credential rotation" from the Block docs) should be dropped before it merges.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and type annotations only; no logic or API call changes.
> 
> **Overview**
> Corrects two public API documentation mismatches verified against the live platform—**no runtime behavior changes**.
> 
> **`ExplorerAPIClient.check_framework_price`** is annotated and documented as returning `Optional[float]` (quoted token price or `None`), replacing a mistaken `dict` return type and copy-pasted “Dictionary of available filters” text that did not match the unwrapped `price` from `POST …/framework/order`.
> 
> **`OntologyAPIClient.get_events`** docstring is rewritten to match `GET …/ontology/events`: `entity_id` / `entity_representation` refer to the **non-event** entity being filtered (pair required), search uses relevance (not “vector similarity”), entity filters on search apply only when `insight_id` is set, search `total` can reflect a capped batch, and the response shape is documented as `{total, page, size, pages, entities}` with the expected entity fields including `relevance_score` on search.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c762ee2f5f36e1dc9c76efd733b5a128695b8300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->