### PR TITLE
fix: correct return types for get_framework_status and panel-debias info

### DIFF
--- a/src/carbonarc/explorer.py
+++ b/src/carbonarc/explorer.py
@@ -348,9 +348,16 @@ class ExplorerAPIClient(BaseAPIClient):
         else:
             return response
     
-    def get_valid_insights_for_framework_panel_debias(self, framework_id: str) -> List[int]:
+    def get_valid_insights_for_framework_panel_debias(self, framework_id: str) -> List[Dict[str, Any]]:
         """
         Retrieve valid insights for a framework.
+
+        Args:
+            framework_id: Framework ID.
+
+        Returns:
+            List of insight dictionaries, each with "insight_id", "insight_label",
+            and "insight_type".
         """
         endpoint = f"{framework_id}/panel-debias-info"
         url = f"{self.base_framework_url}/{endpoint}"
@@ -405,9 +412,20 @@ class ExplorerAPIClient(BaseAPIClient):
         url = f"{self.base_framework_url}/{endpoint}"
         return self._get(url)
     
-    def get_framework_status(self, framework_id: Union[str, list[str]]) -> dict:
+    def get_framework_status(self, framework_id: Union[str, list[str]]) -> List[Dict[str, Any]]:
         """
-        Retrieve status for a specific framework.
+        Retrieve status for one or more frameworks.
+
+        Args:
+            framework_id: A single framework ID or a list of framework IDs.
+
+        Returns:
+            List of status dictionaries, one per requested framework — a single
+            framework ID also returns a one-element list. Each entry contains
+            "framework_id", "refresh_available", "reinstatement_available",
+            "framework_refresh_timestamp", "framework_reinstatement_timestamp",
+            "insight_refresh_timestamp", "insight_reinstatement_timestamp",
+            "last_reinstatement_reason", and "message".
         """
         endpoint = "framework-status"
         url = f"{self.base_framework_url}/{endpoint}"


### PR DESCRIPTION
Found by the daily SDK↔docs parity check. Both annotations contradict the power-api routes they call (verified against `origin/main` of the `cake` monorepo). Annotations and docstrings only — **no behavior change**.

## 1. `get_framework_status` → not a `dict`

```python
@router.get("/framework-status", response_model=list[FrameworkDataStatus])
...
    if not isinstance(framework_id, list):
        return [framework_status]   # single ID is wrapped in a list
```

The route always responds with a JSON array, so `-> dict` is wrong even in the single-framework case. Corrected to `List[Dict[str, Any]]`, and the docstring now names the nine fields of `FrameworkDataStatus`.

This annotation actively misled the docs: three starter guides call `.get("status")` on the result, which raises `AttributeError` on a list. Companion docs fix: Carbon-Arc/carbonarc-documentation#306

## 2. `get_valid_insights_for_framework_panel_debias` → not `List[int]`

```python
@router.get(
    "/{framework_id}/panel-debias-info", response_model=List[PanelDebiasingInfo]
)
```

```python
class PanelDebiasingInfo(BaseModel):
    insight_id: int
    insight_label: str
    insight_type: str
```

The method returns `self._get(url)` unmodified, so callers get a list of **dicts**, not a list of ints. Corrected to `List[Dict[str, Any]]` with the keys named in the docstring.

## Note (not fixed here)

`stream_framework_data` looks broken independently of this change: it calls `get_framework_data(framework_id=..., fetch_all=True)` inside its loop without ever passing `page`, so it re-requests the entire dataset on every iteration and yields the same full response `pages` times. Fixing it means deciding the intended pagination semantics, so I left it alone rather than guess at a behavior change.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and typing only; no changes to request logic or return values at runtime.
> 
> **Overview**
> Aligns **type hints and docstrings** on `ExplorerAPIClient` with the power-api routes—**no runtime behavior change**.
> 
> **`get_framework_status`** is annotated as `List[Dict[str, Any]]` instead of `dict`, matching a JSON array response (including a single ID wrapped in a one-element list). The docstring documents the nine `FrameworkDataStatus` fields per entry.
> 
> **`get_valid_insights_for_framework_panel_debias`** is annotated as `List[Dict[str, Any]]` instead of `List[int]`, reflecting dicts with `insight_id`, `insight_label`, and `insight_type`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b25aaece9e908cc10b9a951640dff430ec58296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->