### PR TITLE
fix: get_data_dictionary returns a list, not a dict

### DIFF
--- a/src/carbonarc/data.py
+++ b/src/carbonarc/data.py
@@ -109,18 +109,20 @@ class DataAPIClient(BaseAPIClient):
 
         return file_path
 
-    def get_data_dictionary(self, 
+    def get_data_dictionary(self,
                             dataset_id: str,
-                            entity_topic_id: Optional[int] = None) -> dict:
+                            entity_topic_id: Optional[int] = None) -> list:
         """
         Get the data dictionary for a specific dataset from the Carbon Arc API.
-        
+
         Args:
             dataset_id (str): The identifier of the data to retrieve the data dictionary for.
             entity_topic_id (Optional[int]): The identifier of the entity topic to retrieve the data dictionary for. If not provided, all data dictionaries for the dataset will be returned.
-            
+
         Returns:
-            list: A list of dictionaries containing the data dictionary or data dictionaries for the specified dataset.    
+            list: One entry per topic in the dataset, each with entity_topic_id,
+                  label, notes, and a columns mapping of column name to column
+                  metadata.
         """
         endpoint = f"data/{dataset_id}/data-dictionary"
         url = f"{self.base_data_url}/{endpoint}"


### PR DESCRIPTION
One-line annotation fix, found while auditing the `client.data` surface against power-api.

## The bug

`DataAPIClient.get_data_dictionary()` is annotated `-> dict`. The route it calls, `GET /v2/library/data/{dataset_id}/data-dictionary`, is declared `response_model=List[DataDictionary]`, and `DataService.get_data_dictionary_by_dataset_id` returns `[DataDictionary(**item) for item in topic_data_dictionary]`.

The method's own docstring already said "a list of dictionaries", so only the annotation disagreed with reality.

## Why it is worth fixing

The wrong annotation propagated into the customer docs. The Library API reference described this response as a dict of column definitions (`{column_name, data_type, description}`) and shipped examples that silently printed nothing, because each entry is really a *topic* — `{entity_topic_id, label, notes, columns}`, with `columns` keyed by column name. Corrected in Carbon-Arc/carbonarc-documentation#307.

I also expanded the `Returns:` line to name those fields, so the shape is discoverable without reading the platform schema.

## Not included

`get_dataset_schedule()` has the same class of bug in the other direction — annotated `-> list`, but `/v2/library/schedule/{dataset_id}` returns `CakeTaskScheduleResponse` = `{"schedules": [...]}`. That is already fixed by open PR #93, so I left it alone rather than duplicating it.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and typing only; no logic or API call changes.
> 
> **Overview**
> Aligns **`DataAPIClient.get_data_dictionary()`** with the Library API: the return annotation is **`list`** instead of **`dict`**, matching `GET /v2/library/data/{dataset_id}/data-dictionary` (`List[DataDictionary]`).
> 
> The **`Returns:`** docstring now states one list element per topic (`entity_topic_id`, `label`, `notes`, and a `columns` map), instead of a vague “list of dictionaries.” Runtime behavior is unchanged; this fixes type hints and downstream docs that assumed a flat column dict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1918aa09405b28a0023def42fd5d47e092879c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->