### PR TITLE
fix: expose page/size on get_entities_for_insight (SDK was capped at 25)

### DIFF
--- a/src/carbonarc/ontology.py
+++ b/src/carbonarc/ontology.py
@@ -231,12 +231,29 @@ class OntologyAPIClient(BaseAPIClient):
         url = f"{self.base_ontology_url}/entity/{entity_id}/insights"
         return self._get(url, params=params)
     
-    def get_entities_for_insight(self, insight_id: int) -> dict:
+    def get_entities_for_insight(
+        self,
+        insight_id: int,
+        page: int = 1,
+        size: int = 100,
+    ) -> dict:
         """
         Retrieve entities for a specific insight.
+
+        The endpoint is paginated and its response carries no total count, so a
+        full page means there are probably more entities to fetch.
+
+        Args:
+            insight_id: Insight ID.
+            page: Page number (default 1).
+            size: Number of entities per page (default 100).
+
+        Returns:
+            Dictionary with an ``entities`` list for the requested page.
         """
+        params = {"page": page, "size": size}
         url = f"{self.base_ontology_url}/insight/{insight_id}/entities"
-        return self._get(url)
+        return self._get(url, params=params)
     
     def get_subjects(self) -> dict:
         """
@@ -268,7 +285,10 @@ class OntologyAPIClient(BaseAPIClient):
         
     def get_ontology_version(self) -> dict:
         """
-        Retrieve the current ontology version.
+        Retrieve the available ontology versions.
+
+        Alias of :meth:`get_ontology_versions` — both call the same endpoint and
+        return ``{"versions": [...]}``, not a single version.
         """
         url = f"{self.base_ontology_url}/ontology-versions"
         return self._get(url)
@@ -283,6 +303,9 @@ class OntologyAPIClient(BaseAPIClient):
     def get_ontology_versions(self) -> Dict[str, Any]:
         """
         Retrieve the available ontology versions.
+
+        Returns:
+            Dictionary with a ``versions`` list of version strings.
         """
         url = f"{self.base_ontology_url}/ontology-versions"
         return self._get(url)


### PR DESCRIPTION
## What drifted

`client.ontology.get_entities_for_insight()` sent no pagination params, but the platform route paginates and defaults to a page size of **25**.

`GET /v2/ontology/insight/{insight_id}/entities` (`app/power-api/app/api/v2/routes/ontology.py:510`):

```python
async def entities_for_insight(
    insight_id: int,
    page: int = Query(PAGE, description="Page number"),
    size: int = Query(LIMIT, description="Page size"),
    ...
):
    return {"entities": await service.find_entities_from_insight(insight_id, page, size)}
```

`PAGE = 1`, `LIMIT = 25` (`app/power-api/app/constants.py:21-22`), and `find_entities_from_insight` really does apply `limit`/`offset`. So the SDK method returned the first 25 entities for an insight and gave callers no way to reach the rest — and `EntityInsightsResponse` is just `{entities: List[Dict]}` with no `total`, so nothing in the payload revealed the truncation.

This matters because the documented purpose of the method is "discover which entities you can query for a particular metric" before buying a framework. Silently seeing 25 of them is the wrong answer to that question.

## Fix

Adds `page: int = 1, size: int = 100`, matching `get_entities`, `get_insights` and `get_events` in this same client.

**Behavior change:** callers who omit the new params now get up to 100 entities per call instead of 25. That is the intent — 25 was the route default leaking through, not a deliberate SDK choice — but it is a change, so calling it out.

Also corrects `get_ontology_version()`'s docstring. It says "Retrieve the current ontology version" but hits `/ontology-versions` and returns `{"versions": [...]}` — byte-for-byte the same call as `get_ontology_versions()`.

## Companion docs PR

https://github.com/Carbon-Arc/carbonarc-documentation/pull/308 documents the new params and the missing-total caveat, and fixes a separate batch of `client.ontology` response-shape errors found in the same audit.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SDK-only pagination and documentation fixes; default page size increases from 25 to 100 for callers who omit params.
> 
> **Overview**
> Fixes **`get_entities_for_insight`** silently returning only the API’s default **25** entities by adding **`page`** and **`size`** (defaults **1** / **100**), aligned with **`get_entities`**, **`get_insights`**, and **`get_events`**, and passing them as query params. Docs note the response has **no total**—a full page likely means more pages exist.
> 
> **Behavior change:** callers who don’t pass pagination now receive up to **100** entities per request instead of **25**.
> 
> Docstrings for **`get_ontology_version`** and **`get_ontology_versions`** are corrected to describe the **`/ontology-versions`** response (`{"versions": [...]}`) rather than a single “current” version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b22c01e8de8b685f7efde3c15380936187db9fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
