### PR TITLE
fix: transcript entity filter takes ids, region takes a list, add facet methods

### DIFF
--- a/src/carbonarc/transcripts.py
+++ b/src/carbonarc/transcripts.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from carbonarc.utils.client import BaseAPIClient
 
@@ -23,7 +23,7 @@ class TranscriptAPIClient(BaseAPIClient):
         ticker: Optional[str] = None,
         entity: Optional[List[str]] = None,
         transcript_type: Optional[str] = None,
-        region: Optional[str] = None,
+        region: Optional[Union[str, List[str]]] = None,
         search: Optional[str] = None,
         interview_date_from: Optional[str] = None,
         interview_date_to: Optional[str] = None,
@@ -41,9 +41,13 @@ class TranscriptAPIClient(BaseAPIClient):
 
         Args:
             ticker: Filter by ticker symbol (entity label).
-            entity: Filter by one or more entity labels.
+            entity: Filter by one or more entity **ids**, not labels. Ids come
+                from :meth:`list_transcript_entities`; a label such as
+                ``"Apple Inc"`` matches nothing.
             transcript_type: Filter by transcript type (e.g. ``"expert_interview"``).
-            region: Filter by region (e.g. ``"North America"``).
+            region: Filter by one or more regions (e.g. ``"North America"`` or
+                ``["North America", "Europe"]``). Exact match; values come
+                from :meth:`list_transcript_regions`.
             search: Search in title and description.
             interview_date_from: ISO date string lower bound, inclusive (e.g. ``"2024-01-01"``).
             interview_date_to: ISO date string upper bound, inclusive (e.g. ``"2024-12-31"``).
@@ -55,6 +59,8 @@ class TranscriptAPIClient(BaseAPIClient):
 
         Returns:
             Dict with ``transcripts`` (list), ``total`` (int), ``page`` (int), and ``size`` (int).
+            Each transcript carries a ``price``: the token cost for your client,
+            which may differ from another client's price for the same transcript.
         """
         params: dict = {"sort_by": sort_by, "order": order, "page": page, "size": size}
         for key, val in {
@@ -73,6 +79,29 @@ class TranscriptAPIClient(BaseAPIClient):
             params["is_purchased"] = is_purchased
         return self._get(self._base_url, params=params)
 
+    def list_transcript_entities(self) -> List[dict]:
+        """List the entity facets available across the transcripts you can browse.
+
+        Use this to discover the entity ids accepted by the ``entity`` filter on
+        :meth:`list_transcripts`.
+
+        Returns:
+            List of dicts with ``id`` (entity id), ``label`` (display name, e.g.
+            a ticker), and ``count`` (number of transcripts tagged with it).
+        """
+        return self._get(f"{self._base_url}/entities")
+
+    def list_transcript_regions(self) -> List[dict]:
+        """List the region facets available across the transcripts you can browse.
+
+        Use this to discover the values accepted by the ``region`` filter on
+        :meth:`list_transcripts`.
+
+        Returns:
+            List of dicts with ``region`` (str) and ``count`` (int).
+        """
+        return self._get(f"{self._base_url}/regions")
+
     def get_transcript(self, transcript_id: str) -> dict:
         """Get metadata for a single transcript.
 
@@ -84,7 +113,8 @@ class TranscriptAPIClient(BaseAPIClient):
 
         Returns:
             Dict with transcript metadata, ``has_pdf`` flag (whether a PDF
-            version is available), and ``is_purchased`` flag.
+            version is available), ``is_purchased`` flag, and ``price`` (the
+            token cost for your client).
         """
         return self._get(f"{self._base_url}/{transcript_id}")
 


### PR DESCRIPTION
Found by the scheduled SDK/docs parity check. Every claim below was verified against `power-api` on `origin/main` in the cake monorepo, not inferred.

## 1. `entity` filters by entity **id**, not label

`app/power-api/app/api/v2/repository/transcripts.py`:

```python
if params.ticker is not None:
    conditions.append(Transcript.entities.contains([{"label": params.ticker}]))
if params.entity:
    conditions.append(
        or_(*(Transcript.entities.contains([{"id": e}]) for e in params.entity))
    )
```

`ticker` matches the label; `entity` matches the id. The route says so too ("Filter by entity id (repeatable)"). The SDK docstring promised "one or more entity labels", so a caller following it gets zero results with no error.

## 2. `region` accepts a list

The route declares `region: Optional[list[str]]` and the repository applies `Transcript.region.in_(params.region)`. The SDK typed it `Optional[str]`, so callers could only ever filter one region. Widened to `Optional[Union[str, List[str]]]`; a bare string still works.

## 3. Facet endpoints were never exposed

`GET /v2/transcripts/entities` and `GET /v2/transcripts/regions` have been live since PRO-1681 (2026-06-30), which is four days after the transcripts client was written. They return `{id, label, count}` and `{region, count}` respectively, scoped to the same published/anonymized/entitled set as `list_transcripts`.

They matter here: without `/entities` there is no way to obtain the ids fix 1 requires, so the `entity` filter is unusable from the SDK today. Added as `list_transcript_entities()` and `list_transcript_regions()`.

## 4. `price` is per client

`TranscriptListItem` and `TranscriptDetailItem` both carry `price`, and PRO-3000 (2026-08-04) made it configurable per client on top of a global default. Named in the return docstrings so callers know not to assume a flat rate.

## Testing

Docstring, type-hint, and two-method addition only. No behavior change to existing calls: a `str` region serializes exactly as before.

Matching docs change: https://github.com/Carbon-Arc/carbonarc-documentation/pull/310

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring and type-hint updates plus thin GET wrappers; no change to existing request serialization for string regions.
> 
> **Overview**
> Brings **`TranscriptAPIClient`** in line with the live Transcripts API after a docs/SDK parity check.
> 
> **`list_transcripts`** docstrings and types now state that **`entity`** expects **entity ids** (not display labels), and **`region`** accepts a **single string or a list** of regions. Return docs note **per-client `price`** on list and detail responses.
> 
> Adds **`list_transcript_entities()`** and **`list_transcript_regions()`** so callers can discover valid filter values for those parameters. Existing call patterns are unchanged (e.g. a string `region` still serializes the same).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8a418504c76bb4944974875beeb4580d5aa7a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
