### PR TITLE
fix: correct the dataset_status docstring response shape

### DIFF
--- a/src/carbonarc/block.py
+++ b/src/carbonarc/block.py
@@ -441,12 +441,29 @@ class BlockAPIClient(BaseAPIClient):
                         "vendor": "...",
                         "description": "...",
                         "status": "ready" | "coming_soon" | ...,
+                        "lag_days": 180,               # normalized from "lag"
                         "cuts": [
                             {
                                 "cut": "...",
-                                "lags": ["6m", ...],
                                 "annual_price": "...",
-                                "request_statuses": {"6m": "APPROVED", ...},
+                                # "lags" + "request_statuses" are replaced
+                                # by one entry per (cut, lag) SKU:
+                                "skus": [
+                                    {
+                                        "lag_days": 180,
+                                        "request_status": "APPROVED",
+                                        "arns": [
+                                            {
+                                                "id": "...",
+                                                "aws_arn": "arn:aws:iam::...",
+                                                "status": "active",
+                                                "created_at": "...",
+                                            },
+                                            ...
+                                        ],
+                                    },
+                                    ...
+                                ],
                                 ...
                             },
                             ...
@@ -457,7 +474,10 @@ class BlockAPIClient(BaseAPIClient):
                         {
                             "id": "...",
                             "status": "pending_block_admin" | ...,
-                            "lag": "...", "cut": "...",
+                            "lag_days": 180,           # normalized from "lag"
+                            "cut": "...",
+                            "internal_queue_step":
+                                "pending" | "approved" | "rejected" | None,
                             "requestor_email": "...",
                             "approved_by_block_admin": "...",
                             "approved_by_compliance": "...",
@@ -467,6 +487,10 @@ class BlockAPIClient(BaseAPIClient):
                         ...
                     ],
                 }
+
+        The dataset-level ``dataset_id`` and the raw ``lag`` strings are
+        stripped from ``catalog`` and from each request; both are echoed
+        at the top level or in normalized ``lag_days`` form.
         """
         catalog_entry = next(
             (


### PR DESCRIPTION
`dataset_status()` reshapes the catalog payload before returning it, but its `Returns:` block still documented the **raw** `list_datasets()` shape. A caller following the docstring hits a `KeyError`.

## What the code actually does

`_reshape_cuts_with_arns` builds each cut as:

```python
new_cut = {k: v for k, v in cut.items() if k not in {"lags", "request_statuses"}}
new_cut["skus"] = skus
```

so `lags` and `request_statuses` are **gone**, replaced by a `skus` array (one entry per `(cut, lag)`, each carrying its own `request_status` and the ARNs registered against it). Likewise the dataset-level `lag` and each request's `lag` are stripped and re-emitted as integer `lag_days`, and `internal_queue_step` is added to every request row.

Verified by running the helper against an `ArnRow`-shaped payload:

```
reshaped cut keys: ['annual_price', 'bulk_granted', 'cut', 'sample_available', 'skus']
sku arn keys    : ['aws_arn', 'created_at', 'id', 'status']
lag_to_days("6m") = 180
```

The docstring previously showed `cuts[].lags`, `cuts[].request_statuses`, and a per-request `lag`, none of which exist in the returned dict.

## Note on direction

This is a **docstring-only** change; no behavior is touched. The published docs already describe the reshaped output correctly, so the docstring was the side that was wrong. The ARN entries are keyed `aws_arn` (matching the CAMS `ArnRow` schema), which the docstring now shows explicitly.

Companion docs PR: Carbon-Arc/carbonarc-documentation#314 corrects the same namespace's response shapes on the published Block API reference (including an `arns` example that used a nonexistent `arn` key).

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in a docstring; no runtime behavior is modified.
> 
> **Overview**
> Updates the **`dataset_status()`** `Returns:` docstring so it matches the dict the method already builds, instead of the raw **`list_datasets()`** cut shape.
> 
> The documented **`catalog`** now shows **`lag_days`**, per-cut **`skus`** (with **`lag_days`**, **`request_status`**, and **`arns`** using **`aws_arn`**), and notes that **`lags`** / **`request_statuses`** are removed. **`requests`** entries document **`lag_days`**, **`internal_queue_step`**, and the absence of raw **`lag`**, plus a short note that redundant **`dataset_id`** / **`lag`** fields are stripped from nested objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ea539fd181a25ff9026de3e8d4aa98c14500f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->