### PR TITLE
fix: expose page/size on get_order_history and get_insights_by_dataset (silently capped at 25)

### DIFF
--- a/src/carbonarc/client.py
+++ b/src/carbonarc/client.py
@@ -36,15 +36,23 @@ class PlatformAPIClient(BaseAPIClient):
         """
         raise NotImplementedError("get_usage() has been deprecated and is not available in the API. Please use get_order_history() instead.")
     
-    def get_order_history(self) -> dict:
+    def get_order_history(self, page: int = 1, size: int = 100) -> dict:
         """
         Retrieve order history.
 
+        The response is paginated. Use ``total`` and ``pages`` to decide
+        whether more pages need to be fetched.
+
+        Args:
+            page: Page number (default 1).
+            size: Number of orders per page (default 100).
+
         Returns:
-            Dictionary of order history.
+            Dictionary with ``total``, ``page``, ``size``, ``pages`` and an
+            ``items`` list of orders.
         """
         url = f"{self.base_platform_url}/me/orders"
-        return self._get(url)
+        return self._get(url, params={"page": page, "size": size})
     
     def get_order_details(self, order_id: str) -> dict:
         """

--- a/src/carbonarc/data.py
+++ b/src/carbonarc/data.py
@@ -197,18 +197,29 @@ class DataAPIClient(BaseAPIClient):
 
         return self._get(url)
 
-    def get_insights_by_dataset(self, dataset_id: str) -> dict:
+    def get_insights_by_dataset(
+        self,
+        dataset_id: str,
+        page: int = 1,
+        size: int = 100,
+    ) -> dict:
         """
-        Retrieve all insights associated with a specific dataset.
+        Retrieve the insights associated with a specific dataset.
+
+        The response is paginated. Use ``total`` and ``pages`` to decide
+        whether more pages need to be fetched.
 
         Args:
             dataset_id: The identifier of the dataset to retrieve insights for.
+            page: Page number (default 1).
+            size: Number of insights per page (default 100, maximum 100).
 
         Returns:
-            Dictionary containing the insights for the specified dataset.
+            Dictionary with ``total``, ``page``, ``size``, ``pages`` and an
+            ``items`` list of insights for the specified dataset.
         """
         url = f"{self.base_data_url}/data/{dataset_id}/insights"
-        return self._get(url)
+        return self._get(url, params={"page": page, "size": size})
 
     def get_library_version_changes(
         self, 


### PR DESCRIPTION
## What drifted

Two SDK methods call **paginated** power-api routes but take no pagination arguments, so callers silently receive only the route's default first page and have no way to reach the rest.

| SDK method | Route | Route pagination | SDK signature (before) |
| --- | --- | --- | --- |
| `client.client.get_order_history()` | `GET /v2/clients/me/orders` | `page = Query(PAGE, ge=1)`, `size = Query(LIMIT, ge=0)` | `()` |
| `client.data.get_insights_by_dataset()` | `GET /v2/library/data/{dataset_id}/insights` | `page = Query(PAGE, ge=1)`, `size = Query(LIMIT, ge=1, le=100)` | `(dataset_id)` |

`LIMIT = 25` (`app/power-api/app/constants.py`), so **both were capped at 25 rows**.

Nothing in the SDK surfaced the truncation: both routes return a `PaginatedResponse`-shaped body (`total`, `page`, `size`, `pages`, `items`), but a caller who does not inspect `total`/`pages` just sees a short list. The published docs made it worse by describing `get_insights_by_dataset()` as retrieving *"all insights associated with a dataset"* and printing `"Total Insights: 33 (page 1 of 2)"` while iterating only the 25 items received.

Response models verified on `origin/main` of the monorepo:
- `OrderPaginatedResponse` (`app/power-api/app/api/v2/schemas/orders.py`) = `{total, page, size, pages, items: List[FrameworkOrderRead]}`
- `InsightResponse(PaginatedResponse)` (`app/power-api/app/api/v2/schemas/query_builder.py`) = `{total, page, size, pages, items: List[InsightResponseItem]}`

## The fix

Adds `page: int = 1, size: int = 100` to both, matching the convention already used by `get_entities` / `get_insights` / `get_events`, and documents the paginated response in each docstring.

Verified the built URLs and params against the real routes:

```
get_insights_by_dataset("CA0056") -> https://api.carbonarc.co/v2/library/data/CA0056/insights {'params': {'page': 1, 'size': 100}}
get_order_history()               -> https://api.carbonarc.co/v2/clients/me/orders            {'params': {'page': 1, 'size': 100}}
```

`size=100` is within the insights route's `le=100` cap, and the orders route has no upper bound.

## Behavior change worth a reviewer's attention

The **default page size goes from 25 to 100** for both methods. That is the point of the change, but it is a visible behavior change for existing callers who were relying on receiving 25 rows.

## Related

- Docs side of the same drift: Carbon-Arc/carbonarc-documentation#315
- Same class of bug as #109 (`get_entities_for_insight` was capped at 25 for the same reason).
- Minor merge note: #105 also edits `src/carbonarc/data.py` near this method (it removes `get_graph_data`), but does not touch `get_insights_by_dataset` itself.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Backward-compatible signatures with a changed default page size (25→100) can affect callers that assumed smaller result sets; changes are limited to read-only list endpoints.
> 
> **Overview**
> **Fixes silent truncation** on `get_order_history()` and `get_insights_by_dataset()` by forwarding **`page` and `size`** query params (defaults `page=1`, `size=100`), aligned with other paginated SDK helpers.
> 
> Both methods now document the **`total` / `pages` / `items`** response shape so callers can fetch additional pages. Docstrings no longer imply “all insights” for a dataset when only one page is returned.
> 
> **Review note:** existing callers that did not pass pagination will see **up to 100 rows per call** instead of the API default **25**, which is intentional but is a visible behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db1f922e2de2eb280be175fa26e1fa526aff2770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
