### PR TITLE
fix: download_transcript returns file bytes, not a presigned URL (PRO-3348)

### DIFF
--- a/src/carbonarc/transcripts.py
+++ b/src/carbonarc/transcripts.py
@@ -83,8 +83,9 @@ class TranscriptAPIClient(BaseAPIClient):
             transcript_id: UUID of the transcript.
 
         Returns:
-            Dict with transcript metadata, ``has_pdf`` flag (whether a PDF
-            version is available), and ``is_purchased`` flag.
+            Dict with transcript metadata, ``has_pdf`` flag (whether the source
+            supplied a PDF; it does not gate :meth:`download_transcript`, which
+            can render a PDF for any transcript), and ``is_purchased`` flag.
         """
         return self._get(f"{self._base_url}/{transcript_id}")
 
@@ -103,19 +104,28 @@ class TranscriptAPIClient(BaseAPIClient):
         """
         return self._post(f"{self._base_url}/{transcript_id}/purchase")
 
-    def download_transcript(self, transcript_id: str, fmt: str = "txt") -> dict:
-        """Get a presigned download URL for a purchased transcript.
+    def download_transcript(self, transcript_id: str, fmt: str = "txt") -> bytes:
+        """Download a purchased transcript as file bytes.
 
-        The URL expires in 15 minutes. Also records the download for audit
-        purposes.
+        The file is built per request from the canonical transcript text and
+        stamped with the license line for the calling account, so no two
+        accounts receive identical bytes. Both formats are always available: the
+        PDF is rendered from that same text rather than served from a stored
+        PDF. The download is also recorded for audit purposes.
 
         Args:
             transcript_id: UUID of the purchased transcript.
             fmt: File format — ``"txt"`` (default) or ``"pdf"``.
 
         Returns:
-            Dict with ``url`` (presigned S3 URL), ``expires_in`` (seconds), and ``format``.
+            The raw file bytes: UTF-8 text for ``"txt"``, PDF for ``"pdf"``.
+
+        Raises:
+            ForbiddenError: The account lacks the Transcripts entitlement (403).
+            requests.exceptions.HTTPError: If the API request fails, e.g. a 402
+                when the transcript has not been purchased or a 404 when the
+                transcript does not exist.
         """
-        return self._get(
+        return self._stream(
             f"{self._base_url}/{transcript_id}/download", params={"fmt": fmt}
-        )
+        ).content


### PR DESCRIPTION
## What drifted

The platform changed the customer transcript download route out from under this method.
cake `45f2b3bca30` (PRO-3348, merged 2026-08-11) turned
`GET /v2/transcripts/{transcript_id}/download` from

```python
response_model=TranscriptDownloadResponse   # {"url": ..., "expires_in": 900, "format": ...}
```

into

```python
response_class=StreamingResponse            # the file bytes
```

The route now builds the file per request from the canonical transcript text and stamps
it with the caller's license line, so a presigned URL to the unmarked original is never
handed out on the customer path. `Content-Type` is `text/plain; charset=utf-8` or
`application/pdf`, with `Content-Disposition: attachment` and `Content-Length`.

The presigned-URL JSON shape still exists, but only on the admin mount, as
`GET /v2/transcripts/internal/{transcript_id}/download-url`. That is a different router
(`prefix="/transcripts/internal"`) and is not the path this SDK calls.

## Why this is a break, not a cosmetic mismatch

`download_transcript` went through `_get`, which is `request_manager.get(url).json()` with
no content-type check. Against the new route that raises for both formats. Verified
locally by driving the real method against a `requests.Response` shaped like the new
response:

```
--- fmt=txt  Content-Type: text/plain; charset=utf-8
  OLD (_get -> .json()): JSONDecodeError: Expecting value: line 1 column 1 (char 0)
  NEW (_stream -> .content): bytes, 231 bytes
--- fmt=pdf  Content-Type: application/pdf
  OLD (_get -> .json()): JSONDecodeError: Expecting value: line 1 column 1 (char 0)
  NEW (_stream -> .content): bytes, 51 bytes
```

The request itself was already correct and is unchanged:
`GET {host}/v2/transcripts/{id}/download` with `params={"fmt": ...}`.

## The fix

Switched to `_stream(...).content`, which is what `get_tearsheet_pdf` already uses for a
byte-returning endpoint. Deliberately not `get_stream`, since that mutates the shared
session's `Accept` header for every later request.

Two docstring claims that the same platform change invalidated:

- The route no longer returns 422 for `fmt="pdf"` when the source supplied no PDF. The
  PDF is rendered from the canonical text, so both formats are always available.
- `get_transcript`'s `has_pdf` no longer gates downloading a PDF. It reports only whether
  the source supplied one.

Documented `ForbiddenError` for the 403 entitlement gate, because `_raise_for_status`
converts 403 to `ForbiddenError` and 409 to `AuthenticationError` rather than re-raising
`HTTPError`.

## Return type change

`dict` becomes `bytes`. This is a signature change but not a behavioral regression: the
current code path raises `JSONDecodeError` on every call, so there is no working behavior
to preserve.

## Please hold merge until PRO-3348 deploys

PRO-3348 is on cake `main` but is **not** in any `power-api/release-*` branch yet (latest
cut is `power-api/release-2026-08-06`, and the commit landed 08-11), so production still
serves the presigned-URL JSON. Merging this before the platform change ships would break
`download_transcript` against prod in the opposite direction. It should land with or after
that deploy.

## Related

Matching docs change: Carbon-Arc/carbonarc-documentation#316 (https://github.com/Carbon-Arc/carbonarc-documentation/pull/316)

🤖 Generated with Claude Code
