### PR TITLE
fix: give the 409 AuthenticationError the same context as the 403

### DIFF
--- a/src/carbonarc/utils/manager.py
+++ b/src/carbonarc/utils/manager.py
@@ -1,5 +1,6 @@
 import logging
 from http import HTTPStatus
+from typing import Optional
 
 import requests
 from bs4 import BeautifulSoup
@@ -71,22 +72,35 @@ class HttpRequestManager:
             self.request_session.get(url, auth=self.auth_token, stream=True, **kwargs)
         )
 
+    @staticmethod
+    def _detail_from(response: requests.Response) -> Optional[str]:
+        """The API's ``detail`` string, when the body carries one."""
+        try:
+            body = response.json()
+        except ValueError:
+            return None
+        if isinstance(body, dict):
+            return body.get("detail")
+        return None
+
     def _raise_for_status(self, response: requests.Response) -> requests.Response:
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == HTTPStatus.CONFLICT:
-                raise AuthenticationError("Conflict error")
+                # Carries the same context as the 403 branch: without
+                # status_code/response, a caller inspecting the exception
+                # cannot tell a conflict apart from any other
+                # AuthenticationError, and the API's explanation of what
+                # conflicted is lost.
+                raise AuthenticationError(
+                    self._detail_from(e.response) or "Conflict error",
+                    status_code=e.response.status_code,
+                    response=e.response,
+                ) from e
             if e.response.status_code == HTTPStatus.FORBIDDEN:
-                detail: str | None = None
-                try:
-                    body = e.response.json()
-                    if isinstance(body, dict):
-                        detail = body.get("detail")
-                except ValueError:
-                    pass
                 raise ForbiddenError(
-                    detail or "Forbidden",
+                    self._detail_from(e.response) or "Forbidden",
                     status_code=e.response.status_code,
                     response=e.response,
                 ) from e


### PR DESCRIPTION
## The problem

`_raise_for_status` handles 409 and 403 side by side, but only one of them keeps any context:

```python
if e.response.status_code == HTTPStatus.CONFLICT:
    raise AuthenticationError("Conflict error")          # no status_code, no response
if e.response.status_code == HTTPStatus.FORBIDDEN:
    ...
    raise ForbiddenError(
        detail or "Forbidden",
        status_code=e.response.status_code,              # both populated
        response=e.response,
    ) from e
```

`CarbonArcException.__init__` takes `status_code` and `response`, so on the 409 path both land as `None`. Two things follow:

1. A caller that catches `AuthenticationError` cannot read `e.status_code` to learn it was a conflict. It reads `None`, the same as any hand-constructed instance.
2. The API's explanation of *what* conflicted is discarded. A 409 from `purchase_transcript` on an already-purchased transcript, or from `rotate_polaris_credentials` with nothing to rotate, arrives as the bare string `"Conflict error"` no matter what the body said.

There is also no `from e`, so the 409 loses the underlying `HTTPError` as its cause and the traceback stops at the SDK.

## The change

Pass `status_code` and `response` through, add `from e`, and surface the body's `detail` the way the 403 branch does. The JSON-detail lookup moves into a small `_detail_from` helper so the two branches cannot drift apart again.

`Optional[str]` rather than `str | None` for the helper's return: `pyproject.toml` declares `python = "^3.9"`, and unlike the local variable annotation this replaces, a return annotation on a plain (non-`from __future__`) module is evaluated at import time.

## Behavior change worth a look during review

For a 409 whose body carries a `detail`, the exception message is now that detail rather than the constant `"Conflict error"`. Bodies without a detail still read `"Conflict error"`.

The **exception type is unchanged**, so no `except` clause anywhere needs updating. The only thing that could notice is code matching on the literal message text, which was never a documented contract.

Deliberately not changed here: `AuthenticationError` is arguably the wrong type for a conflict, since it collides with what the name implies and 401 does not raise it. Renaming it or introducing a `ConflictError` is a breaking change to the public exception surface and wants a decision rather than a drive-by, so this PR only makes the existing behavior inspectable.

## Verification

Exercised `_raise_for_status` across 401, 403 (with and without a `detail` body), 404, 409 (with and without a body), 422, 429, 500, 502, 503, and a 200 pass-through. Confirmed after the change:

- 409 raises `AuthenticationError` with `status_code == 409` and `response` set to the originating response
- 403 is unchanged
- 400/401/404/422/429/5xx still raise plain `requests.exceptions.HTTPError` with the status code in the message
- 2xx still returns the response untouched
- a 409 with a non-JSON or non-dict body falls back to `"Conflict error"` rather than raising inside the handler

## Related

Cross-linked with docs PR https://github.com/Carbon-Arc/carbonarc-documentation/pull/319, which documents the SDK's exception types for the first time. That page is written against published 1.1.16, so it does not yet promise `.status_code` on the 409 path. Worth updating that row once this ships.

🤖 Generated with Claude Code
