### PR TITLE
fix: catalog tier takes one value, and request_access has no 409

### DIFF
--- a/src/carbonarc/catalog.py
+++ b/src/carbonarc/catalog.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal, Optional
 
 from carbonarc.utils.client import BaseAPIClient
 
@@ -19,7 +19,7 @@ class CatalogAPIClient(BaseAPIClient):
 
     def list_assets(
         self,
-        tier: Optional[Union[int, list]] = None,
+        tier: Optional[int] = None,
         provider_id: Optional[str] = None,
         category: Optional[str] = None,
         visibility: Optional[str] = None,
@@ -33,18 +33,26 @@ class CatalogAPIClient(BaseAPIClient):
         List approved IDO assets. Results are gated by the caller's plan_type.
 
         Args:
-            tier: Filter by asset tier (1, 2, or 3).
+            tier: Filter by a single asset tier (1, 2, or 3). The API takes one
+                tier per call; a list is serialized as repeated query params and
+                only the last value is applied.
             provider_id: Filter by provider UUID.
             category: Filter by data category.
-            visibility: Filter by visibility ('public', 'gated', 'locked').
+            visibility: Accepted for backwards compatibility but ignored by the
+                API — there is no visibility filter on the route. Use the 'gated'
+                flag on each returned asset instead.
             search: Case-insensitive title search.
             data_type: Filter by data type.
             geography: Filter by geography (exact match within array field).
             frequency: Filter by data frequency.
-            sort: Sort order — 'popularity' (vote count desc) or 'newest' (published_at desc).
+            sort: Sort order — 'popularity' (vote count desc) or 'newest' (publish_date desc).
 
         Returns:
-            Dict with 'assets' list and 'total' count.
+            Dict with 'assets' list and 'total' count. Each asset carries
+            'id', 'source_id', 'provider_id', 'provider_name', 'title', 'status',
+            'tier', 'is_new', 'is_premium', 'publish_date', 'last_validated_date',
+            'gated', 'cta' and a nested 'metadata' object. Vote counts are not
+            included — use get_vote_status() for those.
         """
         params = {k: v for k, v in {
             "tier": tier,
@@ -67,7 +75,10 @@ class CatalogAPIClient(BaseAPIClient):
             asset_id: UUID of the asset to retrieve.
 
         Returns:
-            Dict with asset detail including metadata, samples, and dictionary.
+            Dict with the same fields as a list_assets() asset, plus 'samples'
+            (list) and 'dictionary' (dict or None). Embargoed assets you are not
+            authorized for do not raise — they come back with 'gated' set to True,
+            an empty 'samples' list and a null 'dictionary'.
         """
         return self._get(f"{self.base_catalog_url}/assets/{asset_id}")
 
@@ -102,15 +113,21 @@ class CatalogAPIClient(BaseAPIClient):
         request_type: Literal["access", "diligence", "compliance"] = "access",
     ) -> dict:
         """
-        Submit an access request for a gated or locked asset.
-        Only valid for non-public assets. Raises 409 if an active request already exists.
+        Submit an access request for a gated asset.
+
+        Only valid for assets whose 'gated' flag is True. Requesting access to an
+        asset that is not gated returns 400. Repeat submissions for the same asset
+        are allowed — there is no duplicate-request guard.
 
         Args:
             asset_id: UUID of the asset to request access to.
             request_type: Type of request — 'access', 'diligence', or 'compliance'.
 
         Returns:
-            Dict with request id, status ('pending'), and routed_to.
+            Dict with 'id', 'asset_id', 'client_id', 'user_id', 'request_type',
+            'status' and 'routed_to'. The record is created as 'pending' and flips
+            to 'sent' once the notification to the Carbon Arc team goes out, which
+            is what you normally see. 'routed_to' is currently always 'carbon_arc'.
         """
         return self._post(
             f"{self.base_catalog_url}/assets/{asset_id}/request-access",


### PR DESCRIPTION
Companion to docs PR Carbon-Arc/carbonarc-documentation#322. Found by a full-surface audit of `client.catalog`, the last SDK namespace that had never been checked end to end against the platform.

All three claims below were verified against `origin/main` of the cake monorepo (`app/power-api/app/api/v2/routes/catalog.py`, `services/catalog.py`, `schemas/catalog.py`, `exceptions.py`).

## 1. `tier` was typed as int-or-list, but the route takes one tier

`list_assets` annotated `tier: Optional[Union[int, list]]`. The route declares:

```python
tier: Optional[int] = Query(None, ge=1, le=3, description="Filter by asset tier (1, 2, or 3)")
```

`requests` serializes a list as repeated query params, and FastAPI resolves a scalar-annotated param to the **last** value. Verified with a FastAPI 0.136.1 TestClient probe:

```
requests encodes tier=[1,2] as: http://x/assets?tier=1&tier=2
status: 200 body: {"tier_seen":2}
```

So `list_assets(tier=[1, 2])` silently returns tier 2 assets alone — no error, no warning. The service and repository layers do accept `int | list[int]`, so the capability exists, but the route cannot deliver a list to them. Narrowed the annotation to `Optional[int]` and documented the single-tier rule. Type-annotation change only; no runtime behavior change.

## 2. `request_access` documented a 409 that cannot happen

The docstring said "Raises 409 if an active request already exists." `CatalogService.request_access` carries an explicit comment to the contrary:

```python
# Intentionally no duplicate guard: users may submit again (e.g. follow-up or forgot).
```

The error it *does* raise is `APIRuleViolationError` when the asset is not gated, which `api_error_handler` maps to **400**, not 409. Also corrected the returned status — the record is created `pending` and updated to `sent` once the notification email goes out, which is what a caller normally sees — and noted that `routed_to` is currently always `carbon_arc`.

## 3. `visibility` is accepted but ignored

`list_assets` still sends a `visibility` param the route has no matching `Query(...)` for, so it is dropped. Left the parameter in place for backwards compatibility and documented it as ignored, pointing callers at the `gated` flag on each asset instead.

Also filled in the real field sets in the `Returns:` blocks: vote counts are not in the list response (they are only on the admin-gated `AdminAssetResponse`), and `get_asset` returns a gated card rather than raising for an embargoed asset.

## Notes for review

- This does not touch `list_assets`' `liked_only` gap — the route supports `liked_only: bool` and the SDK does not expose it. Left alone deliberately as a feature addition rather than a parity fix.
- Local bugbot (cursor-agent): NO FINDINGS.

🤖 Generated with Claude Code
